### PR TITLE
fix regex for some m3u8 url cases.

### DIFF
--- a/library/src/main/java/com/devbrackets/android/exomedia/EMVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/EMVideoView.java
@@ -72,7 +72,7 @@ public class EMVideoView extends RelativeLayout implements AudioCapabilitiesRece
         DEFAULT;
 
         public static VideoType get(Uri uri) {
-            if (uri.toString().matches(".*\\.m3u8.*")) {
+            if (uri.toString().matches(".*m3u8.*")) {
                 return VideoType.HLS;
             }
 


### PR DESCRIPTION
for example, the following m3u8 url may fail:

http://pl.youku.com/playlist/m3u8?vid=XMTI5MjIxODIwOA%2525253D%2525253D&keyframe=1&ev=1&ts=1441603988&type=hd2&ep=cSaQG0%2525252BNVccI7SLaiT8bNiWzdnAOXJZ3kmaA%2525252FIgbSMRQMa%2525252FA6DPcqJqwS%2525252Fg%2525253D&token=7057&oip=2021932405&ctype=12&sid=344160398815112a9a271

Using regex may be a relative rude way to recognize the video format, it may fail for some cases still. May be we should use a new way to do it.