### PR TITLE
Added an attribute to hide EMVideoView shutters

### DIFF
--- a/library/src/main/res/values/attributes.xml
+++ b/library/src/main/res/values/attributes.xml
@@ -4,5 +4,6 @@
         <attr name="useDefaultControls" format="boolean" />
         <attr name="videoViewApiImpl" format="reference" />
         <attr name="videoViewApiImplLegacy" format="reference" />
+        <attr name="videoViewHideShutters" format="boolean" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
The shutters were interfering with my implementation of `CENTER_CROP`. I toyed with the idea of using two layout files (one with shutters and one without) which would've had a slight performance increase (doesn't have to inflate the shutters and then remove them), but I figured it was simpler this way, and makes it easier to maintain `exomedia_video_view_layout`. Let me know if you want to go the two layout file route, and I'll put it in.