### PR TITLE
Allow the default DataSource to be overridden

### DIFF
--- a/library/src/main/java/com/devbrackets/android/exomedia/core/builder/DashRenderBuilder.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/builder/DashRenderBuilder.java
@@ -92,6 +92,10 @@ public class DashRenderBuilder extends RenderBuilder {
         this.streamType = streamType;
     }
 
+    protected UriDataSource createManifestDataSource(Context context, String userAgent) {
+        return new DefaultUriDataSource(context, userAgent);
+    }
+
     @Override
     public void buildRenderers(EMExoPlayer player) {
         currentAsyncBuilder = new AsyncRendererBuilder(context, userAgent, url, player, streamType);
@@ -125,7 +129,7 @@ public class DashRenderBuilder extends RenderBuilder {
             this.player = player;
 
             MediaPresentationDescriptionParser parser = new MediaPresentationDescriptionParser();
-            manifestDataSource = new DefaultUriDataSource(context, userAgent);
+            manifestDataSource = createManifestDataSource(context, userAgent);
             manifestFetcher = new ManifestFetcher<>(url, manifestDataSource, parser);
         }
 
@@ -220,7 +224,7 @@ public class DashRenderBuilder extends RenderBuilder {
 
 
             //Create the Sample Source to be used by the Video Renderer
-            DataSource dataSourceVideo = new DefaultUriDataSource(context, bandwidthMeter, userAgent, true);
+            DataSource dataSourceVideo = createDataSource(context, bandwidthMeter, userAgent);
             ChunkSource chunkSourceVideo = new DashChunkSource(manifestFetcher, DefaultDashTrackSelector.newVideoInstance(context, true, filterHdContent), dataSourceVideo,
                     new AdaptiveEvaluator(bandwidthMeter), LIVE_EDGE_LATENCY_MS, elapsedRealtimeOffset, mainHandler, player, EMExoPlayer.RENDER_VIDEO);
             ChunkSampleSource sampleSourceVideo = new ChunkSampleSource(chunkSourceVideo, loadControl, BUFFER_SEGMENTS_VIDEO * BUFFER_SEGMENT_SIZE,
@@ -228,7 +232,7 @@ public class DashRenderBuilder extends RenderBuilder {
 
 
             //Create the Sample Source to be used by the Audio Renderer
-            DataSource dataSourceAudio = new DefaultUriDataSource(context, bandwidthMeter, userAgent, true);
+            DataSource dataSourceAudio = createDataSource(context, bandwidthMeter, userAgent);
             ChunkSource chunkSourceAudio = new DashChunkSource(manifestFetcher, DefaultDashTrackSelector.newAudioInstance(), dataSourceAudio,
                     null, LIVE_EDGE_LATENCY_MS, elapsedRealtimeOffset, mainHandler, player, EMExoPlayer.RENDER_AUDIO);
             ChunkSampleSource sampleSourceAudio = new ChunkSampleSource(chunkSourceAudio, loadControl, BUFFER_SEGMENTS_AUDIO * BUFFER_SEGMENT_SIZE,
@@ -236,7 +240,7 @@ public class DashRenderBuilder extends RenderBuilder {
 
 
             //Create the Sample Source to be used by the Closed Captions Renderer
-            DataSource dataSourceCC = new DefaultUriDataSource(context, bandwidthMeter, userAgent);
+            DataSource dataSourceCC = createDataSource(context, bandwidthMeter, userAgent);
             ChunkSource chunkSourceCC = new DashChunkSource(manifestFetcher, DefaultDashTrackSelector.newAudioInstance(), dataSourceCC,
                     null, LIVE_EDGE_LATENCY_MS, elapsedRealtimeOffset, mainHandler, player, EMExoPlayer.RENDER_CLOSED_CAPTION);
             ChunkSampleSource sampleSourceCC = new ChunkSampleSource(chunkSourceCC, loadControl, BUFFER_SEGMENTS_TEXT * BUFFER_SEGMENT_SIZE,

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/builder/HlsRenderBuilder.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/builder/HlsRenderBuilder.java
@@ -50,6 +50,7 @@ import com.google.android.exoplayer.upstream.DataSource;
 import com.google.android.exoplayer.upstream.DefaultAllocator;
 import com.google.android.exoplayer.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer.upstream.DefaultUriDataSource;
+import com.google.android.exoplayer.upstream.UriDataSource;
 import com.google.android.exoplayer.util.ManifestFetcher;
 import com.google.android.exoplayer.util.ManifestFetcher.ManifestCallback;
 
@@ -82,6 +83,10 @@ public class HlsRenderBuilder extends RenderBuilder {
         this.streamType = streamType;
     }
 
+    protected UriDataSource createManifestDataSource(Context context, String userAgent) {
+        return new DefaultUriDataSource(context, userAgent);
+    }
+
     @Override
     public void buildRenderers(EMExoPlayer player) {
         currentAsyncBuilder = new AsyncRendererBuilder(context, userAgent, url, player, streamType);
@@ -96,7 +101,7 @@ public class HlsRenderBuilder extends RenderBuilder {
         }
     }
 
-    private static final class AsyncRendererBuilder implements ManifestCallback<HlsPlaylist> {
+    private final class AsyncRendererBuilder implements ManifestCallback<HlsPlaylist> {
         private final Context context;
         private final String userAgent;
         private final String url;
@@ -114,7 +119,7 @@ public class HlsRenderBuilder extends RenderBuilder {
             this.player = player;
 
             HlsPlaylistParser parser = new HlsPlaylistParser();
-            playlistFetcher = new ManifestFetcher<>(url, new DefaultUriDataSource(context, userAgent), parser);
+            playlistFetcher = new ManifestFetcher<>(url, createManifestDataSource(context, userAgent), parser);
         }
 
         public void init() {
@@ -168,7 +173,7 @@ public class HlsRenderBuilder extends RenderBuilder {
             }
 
             //Create the Sample Source to be used by the renders
-            DataSource dataSource = new DefaultUriDataSource(context, bandwidthMeter, userAgent, true);
+            DataSource dataSource = createDataSource(context, bandwidthMeter, userAgent);
             HlsChunkSource chunkSource = new HlsChunkSource(true, dataSource, url, playlist, DefaultHlsTrackSelector.newDefaultInstance(context),
                     bandwidthMeter, timestampAdjusterProvider, HlsChunkSource.ADAPTIVE_MODE_SPLICE);
             HlsSampleSource sampleSource = new HlsSampleSource(chunkSource, loadControl,

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/builder/RenderBuilder.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/builder/RenderBuilder.java
@@ -39,6 +39,7 @@ import com.google.android.exoplayer.upstream.DataSource;
 import com.google.android.exoplayer.upstream.DefaultAllocator;
 import com.google.android.exoplayer.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer.upstream.DefaultUriDataSource;
+import com.google.android.exoplayer.upstream.TransferListener;
 
 /**
  * A default RenderBuilder that can process general
@@ -71,12 +72,15 @@ public class RenderBuilder {
         this.streamType = streamType;
     }
 
+    protected DataSource createDataSource(Context context, TransferListener transferListener, String userAgent) {
+        return new DefaultUriDataSource(context, transferListener, userAgent, true);
+    }
 
     public void buildRenderers(EMExoPlayer player) {
         //Create the Sample Source to be used by the renderers
         Allocator allocator = new DefaultAllocator(BUFFER_SEGMENT_SIZE);
         DefaultBandwidthMeter bandwidthMeter = new DefaultBandwidthMeter(player.getMainHandler(), player);
-        DataSource dataSource = new DefaultUriDataSource(context, bandwidthMeter, userAgent, true);
+        DataSource dataSource = createDataSource(context, bandwidthMeter, userAgent);
 
         ExtractorSampleSource sampleSource = new ExtractorSampleSource(Uri.parse(MediaUtil.getUriWithProtocol(uri)), dataSource,
                allocator, BUFFER_SEGMENT_SIZE * BUFFER_SEGMENTS_TOTAL);


### PR DESCRIPTION
This helps with overridding the `HttpDataSource` if it needs to modified (e.g. adding request headers).