### PR TITLE
Add option to not measure ResizingTextureView based on aspect ratio

### DIFF
--- a/library/src/main/java/com/devbrackets/android/exomedia/core/api/VideoViewApi.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/api/VideoViewApi.java
@@ -94,6 +94,8 @@ public interface VideoViewApi {
 
     void setScaleType(@NonNull ScaleType scaleType);
 
+    void setMeasureBasedOnAspectRatioEnabled(boolean doNotMeasureBasedOnAspectRatio);
+
     /**
      * Sets the rotation for the Video
      *

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/ResizingTextureView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/ResizingTextureView.java
@@ -91,6 +91,8 @@ public class ResizingTextureView extends TextureView {
     @IntRange(from = 0, to = 359)
     protected int requestedConfigurationRotation = 0;
 
+    protected boolean measureBasedOnAspectRatioEnabled;
+
     public ResizingTextureView(Context context) {
         super(context);
     }
@@ -110,6 +112,11 @@ public class ResizingTextureView extends TextureView {
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        if(!measureBasedOnAspectRatioEnabled) {
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+            return;
+        }
+
         int width = getDefaultSize(videoSize.x, widthMeasureSpec);
         int height = getDefaultSize(videoSize.y, heightMeasureSpec);
 
@@ -211,6 +218,11 @@ public class ResizingTextureView extends TextureView {
         if (matrixManager.ready()) {
             matrixManager.scale(this, scaleType);
         }
+    }
+
+    public void setMeasureBasedOnAspectRatioEnabled(boolean measureBasedOnAspectRatioEnabled) {
+        this.measureBasedOnAspectRatioEnabled = measureBasedOnAspectRatioEnabled;
+        requestLayout();
     }
 
     /**

--- a/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/EMVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/EMVideoView.java
@@ -651,6 +651,15 @@ public class EMVideoView extends RelativeLayout {
         videoViewImpl.setScaleType(scaleType);
     }
 
+  /**
+   * Measures the underlying {@link VideoViewApi} using the video's aspect ratio if {@code true}
+   *
+   * @param measureBasedOnAspectRatioEnabled whether to measure using the video's aspect ratio or not
+   */
+  public void setMeasureBasedOnAspectRatioEnabled(boolean measureBasedOnAspectRatioEnabled) {
+        videoViewImpl.setMeasureBasedOnAspectRatioEnabled(measureBasedOnAspectRatioEnabled);
+    }
+
     /**
      * Sets the rotation for the Video
      *


### PR DESCRIPTION
###### Fixes issue #164.
- [x] This pull request follows the coding standards

###### This PR changes:
 -  Adds an option to not use aspect ratio when measuring the `VideoViewApi`