### PR TITLE
Fix underlying scaling issues

### DIFF
--- a/library/src/main/java/com/devbrackets/android/exomedia/core/api/VideoViewApi.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/api/VideoViewApi.java
@@ -94,6 +94,8 @@ public interface VideoViewApi {
 
     void setScaleType(@NonNull ScaleType scaleType);
 
+    ScaleType getScaleType();
+
     void setMeasureBasedOnAspectRatioEnabled(boolean doNotMeasureBasedOnAspectRatio);
 
     /**

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/ResizingTextureView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/ResizingTextureView.java
@@ -82,7 +82,7 @@ public class ResizingTextureView extends TextureView {
     protected Point videoSize = new Point(0, 0);
 
     @NonNull
-    protected ScaleType currentScaleType = ScaleType.CENTER_INSIDE;
+    protected ScaleType currentScaleType = ScaleType.NONE;
     @NonNull
     protected MatrixManager matrixManager = new MatrixManager();
 
@@ -91,7 +91,7 @@ public class ResizingTextureView extends TextureView {
     @IntRange(from = 0, to = 359)
     protected int requestedConfigurationRotation = 0;
 
-    protected boolean measureBasedOnAspectRatioEnabled;
+    private boolean measureBasedOnAspectRatioEnabled;
 
     public ResizingTextureView(Context context) {
         super(context);
@@ -114,6 +114,7 @@ public class ResizingTextureView extends TextureView {
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         if(!measureBasedOnAspectRatioEnabled) {
             super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+            notifyOnSizeChangeListener(getMeasuredWidth(), getMeasuredHeight());
             return;
         }
 
@@ -218,6 +219,10 @@ public class ResizingTextureView extends TextureView {
         if (matrixManager.ready()) {
             matrixManager.scale(this, scaleType);
         }
+    }
+
+    public ScaleType getScaleType() {
+        return currentScaleType;
     }
 
     public void setMeasureBasedOnAspectRatioEnabled(boolean measureBasedOnAspectRatioEnabled) {

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/scale/MatrixManager.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/scale/MatrixManager.java
@@ -87,7 +87,10 @@ public class MatrixManager {
      * @param transformMatrix The matrix to add the transformation to
      */
     protected void applyCenter(@NonNull TextureView view, @NonNull Matrix transformMatrix) {
-        applyScale(view, transformMatrix, 1, 1);
+        float xScale = (float) intrinsicVideoSize.x / view.getWidth();
+        float yScale = (float) intrinsicVideoSize.y / view.getHeight();
+
+        applyScale(view, transformMatrix, xScale, yScale);
     }
 
     /**
@@ -102,7 +105,9 @@ public class MatrixManager {
         float yScale = (float)view.getHeight() / intrinsicVideoSize.y;
 
         float scale = Math.max(xScale, yScale);
-        applyScale(view, transformMatrix, scale, scale);
+        xScale = scale / xScale;
+        yScale = scale / yScale;
+        applyScale(view, transformMatrix, xScale, yScale);
     }
 
     /**
@@ -114,14 +119,11 @@ public class MatrixManager {
      * @param transformMatrix The matrix to add the transformation to
      */
     protected void applyCenterInside(@NonNull TextureView view, @NonNull Matrix transformMatrix) {
-        float xScale = (float)view.getWidth() / intrinsicVideoSize.x;
-        float yScale = (float)view.getHeight() / intrinsicVideoSize.y;
-
-        //We min the resulting scale with 1 to make sure we aren't increasing the size
-        float scale = Math.min(xScale, yScale);
-        scale = Math.min(scale, 1F);
-
-        applyScale(view, transformMatrix, scale, scale);
+        if(intrinsicVideoSize.y <= view.getWidth() && intrinsicVideoSize.x <= view.getHeight()) {
+            applyCenter(view, transformMatrix);
+        } else {
+            applyFitCenter(view, transformMatrix);
+        }
     }
 
     /**
@@ -136,7 +138,9 @@ public class MatrixManager {
         float yScale = (float)view.getHeight() / intrinsicVideoSize.y;
 
         float scale = Math.min(xScale, yScale);
-        applyScale(view, transformMatrix, scale, scale);
+        xScale = scale / xScale;
+        yScale = scale / yScale;
+        applyScale(view, transformMatrix, xScale, yScale);
     }
 
     protected void applyScale(@NonNull TextureView view, @NonNull Matrix transformMatrix, float xScale, float yScale) {

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/scale/MatrixManager.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/scale/MatrixManager.java
@@ -30,7 +30,8 @@ public class MatrixManager {
         float xCenter = (float)view.getWidth() / 2F;
         float yCenter = (float)view.getHeight() / 2F;
 
-        Matrix transformMatrix = new Matrix(view.getMatrix());
+        Matrix transformMatrix = new Matrix();
+        view.getTransform(transformMatrix);
         transformMatrix.postRotate(rotation, xCenter, yCenter);
         view.setTransform(transformMatrix);
     }
@@ -53,7 +54,8 @@ public class MatrixManager {
             return false;
         }
 
-        Matrix transformMatrix = new Matrix(view.getMatrix());
+        Matrix transformMatrix = new Matrix();
+        view.getTransform(transformMatrix);
         switch (scaleType) {
             case CENTER:
                 applyCenter(view, transformMatrix);
@@ -66,6 +68,9 @@ public class MatrixManager {
                 break;
             case FIT_CENTER:
                 applyFitCenter(view, transformMatrix);
+                break;
+            case NONE:
+                transformMatrix.setScale(1, 1);
                 break;
         }
 

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/scale/ScaleType.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/scale/ScaleType.java
@@ -9,4 +9,5 @@ public enum ScaleType {
     CENTER_CROP,
     CENTER_INSIDE,
     FIT_CENTER,
+    NONE
 }

--- a/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/EMVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/EMVideoView.java
@@ -649,6 +649,12 @@ public class EMVideoView extends RelativeLayout {
      */
     public void setScaleType(@NonNull ScaleType scaleType) {
         videoViewImpl.setScaleType(scaleType);
+
+        int width = getWidth();
+        int height = getHeight();
+        if(width > 0 && height > 0) {
+            updateVideoShutters(width, height, videoViewImpl.getWidth(), videoViewImpl.getHeight());
+        }
     }
 
   /**
@@ -807,11 +813,19 @@ public class EMVideoView extends RelativeLayout {
     }
 
     protected int calculateVerticalShutterSize(int viewHeight, int videoHeight) {
+        if(videoViewImpl.getScaleType() == ScaleType.CENTER_CROP) {
+            return 0;
+        }
+
         int shutterSize = (viewHeight - videoHeight) / 2;
         return (viewHeight - videoHeight) % 2 == 0 ? shutterSize : shutterSize + 1;
     }
 
     protected int calculateSideShutterSize(int viewWidth, int videoWidth) {
+        if(videoViewImpl.getScaleType() == ScaleType.CENTER_CROP) {
+            return 0;
+        }
+
         int shutterSize = (viewWidth - videoWidth) / 2;
         return (viewWidth - videoWidth) % 2 == 0 ? shutterSize : shutterSize + 1;
     }


### PR DESCRIPTION
###### Fixes issue #167.
- [x] This pull request follows the coding standards

###### This PR changes:
 -  Instantiates the `Matrix` for transformations correctly
 -  Adds `ScaleType.NONE`
 -  Doesn't draw shutters if scale type is `CENTER_CROP`
 -  Adds a `getScaleType` method
 -  Corrects the matrix multiplication for scaling
