### PR TITLE
Use FIT_CENTER for the default scale

### DIFF
--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/ResizingTextureView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/ResizingTextureView.java
@@ -82,7 +82,7 @@ public class ResizingTextureView extends TextureView {
     protected Point videoSize = new Point(0, 0);
 
     @NonNull
-    protected ScaleType currentScaleType = ScaleType.NONE;
+    protected ScaleType currentScaleType = ScaleType.FIT_CENTER;
     @NonNull
     protected MatrixManager matrixManager = new MatrixManager();
 


### PR DESCRIPTION
###### Fixes issue #.
- [x] This pull request follows the coding standards

