### PR TITLE
Add a flag that prevents multiple stops

### DIFF
--- a/library/src/main/java/com/devbrackets/android/exomedia/core/exoplayer/EMExoPlayer.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/exoplayer/EMExoPlayer.java
@@ -67,6 +67,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @SuppressWarnings("unused")
 public class EMExoPlayer implements
@@ -102,6 +103,8 @@ public class EMExoPlayer implements
     private final ExoPlayer player;
     private final Handler mainHandler;
     private final CopyOnWriteArrayList<ExoPlayerListener> listeners;
+
+    private final AtomicBoolean stopped = new AtomicBoolean();
 
     private RenderBuildingState rendererBuildingState;
     private StateStore stateStore = new StateStore();
@@ -257,6 +260,8 @@ public class EMExoPlayer implements
 
         rendererBuilder.buildRenderers(this);
         prepared = true;
+
+        stopped.set(false);
     }
 
     public void onRenderers(TrackRenderer[] renderers, @Nullable BandwidthMeter bandwidthMeter) {
@@ -290,8 +295,10 @@ public class EMExoPlayer implements
     }
 
     public void stop() {
-        player.setPlayWhenReady(false);
-        player.stop();
+        if(!stopped.getAndSet(true)) {
+            player.setPlayWhenReady(false);
+            player.stop();
+        }
     }
 
     public void setPlayWhenReady(boolean playWhenReady) {


### PR DESCRIPTION
###### Fixes issue #125 .
- [x] This pull request follows the coding standards

###### This PR changes:
 -  Adds a flag to `EMExoPlayer` that keeps track of when `stop` is called, and only allows its effects to occur the first time it is called. This flag is cleared at the end of `prepare`. The issue it fixes is that when media finishes playing, `stop` is being called twice. This is a problem when the calls happen in the following scenario:

```java
// media finishes playing
EMExoPlayer.stop(); // sets playWhenReady to false

videoView.setOnCompletionListener(new OnCompletionListener() {
  @Override
  public void onCompletion() {             
    videoView.restart(); // sets playWhenReady to true 
  }
});

EMExoPlayer.stop(); // sets playWhenReady to false, and the restart never happens
```

