### PR TITLE
Fix Surface is not released

### DIFF
--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/ExoVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/ExoVideoView.java
@@ -281,7 +281,9 @@ public class ExoVideoView extends ResizingTextureView implements VideoViewApi, A
 
         @Override
         public boolean onSurfaceTextureDestroyed(SurfaceTexture surfaceTexture) {
+            Surface surface = emExoPlayer.getSurface();
             emExoPlayer.blockingClearSurface();
+            surface.release();
             surfaceTexture.release();
 
             return true;


### PR DESCRIPTION
###### Fixes issue #258.
- [x] This pull request follows the coding standards

###### This PR changes:
 - Call `Surface#release()` when backed SurfaceTexture is released.