### PR TITLE
Fix NullPointerException when getting MediaSourceType form an empty path

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -16,6 +16,10 @@ dependencies {
 
     // ExoPlayer
     compile 'com.google.android.exoplayer:exoplayer:r1.5.11'
+
+    //Android unit tests
+    androidTestCompile 'com.android.support.test:runner:0.5'
+    androidTestCompile "junit:junit:4.12"
 }
 
 android {
@@ -28,6 +32,7 @@ android {
 
         versionCode versionMajor * 10000 + versionMinor * 1000 + versionPatch * 100
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {

--- a/library/src/androidTest/java/com/devbrackets/android/exomedia/util/MediaSourceUtilTest.java
+++ b/library/src/androidTest/java/com/devbrackets/android/exomedia/util/MediaSourceUtilTest.java
@@ -1,13 +1,24 @@
 package com.devbrackets.android.exomedia.util;
 
-import org.junit.Assert;
+import android.net.Uri;
+
+import com.devbrackets.android.exomedia.type.MediaSourceType;
+
 import org.junit.Test;
+
+import static com.devbrackets.android.exomedia.type.MediaSourceType.MP4;
+import static org.junit.Assert.assertEquals;
 
 public class MediaSourceUtilTest {
 
     @Test
-    public void exampleTest() {
-        Assert.assertTrue(true);
+    public void shouldRecogniseMp4FromUri() {
+        verify(MP4, "http://host.com/file.mp4");
+        verify(MP4, "http://host.com/file.mp4?query=\"param\"");
+    }
+
+    private void verify(MediaSourceType mediaSourceType, String uriString) {
+        assertEquals(mediaSourceType, MediaSourceUtil.getType(Uri.parse(uriString)));
     }
 
 }

--- a/library/src/androidTest/java/com/devbrackets/android/exomedia/util/MediaSourceUtilTest.java
+++ b/library/src/androidTest/java/com/devbrackets/android/exomedia/util/MediaSourceUtilTest.java
@@ -7,6 +7,7 @@ import com.devbrackets.android.exomedia.type.MediaSourceType;
 import org.junit.Test;
 
 import static com.devbrackets.android.exomedia.type.MediaSourceType.MP4;
+import static com.devbrackets.android.exomedia.type.MediaSourceType.UNKNOWN;
 import static org.junit.Assert.assertEquals;
 
 public class MediaSourceUtilTest {
@@ -15,6 +16,11 @@ public class MediaSourceUtilTest {
     public void shouldRecogniseMp4FromUri() {
         verify(MP4, "http://host.com/file.mp4");
         verify(MP4, "http://host.com/file.mp4?query=\"param\"");
+    }
+
+    @Test
+    public void shouldReturnUnknownForAnEmptyPath() {
+        verify(UNKNOWN, "http://host.com/");
     }
 
     private void verify(MediaSourceType mediaSourceType, String uriString) {

--- a/library/src/androidTest/java/com/devbrackets/android/exomedia/util/MediaSourceUtilTest.java
+++ b/library/src/androidTest/java/com/devbrackets/android/exomedia/util/MediaSourceUtilTest.java
@@ -1,0 +1,13 @@
+package com.devbrackets.android.exomedia.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MediaSourceUtilTest {
+
+    @Test
+    public void exampleTest() {
+        Assert.assertTrue(true);
+    }
+
+}

--- a/library/src/main/java/com/devbrackets/android/exomedia/util/MediaSourceUtil.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/util/MediaSourceUtil.java
@@ -25,6 +25,9 @@ public class MediaSourceUtil {
     @Nullable
     public static String getExtension(@NonNull Uri uri) {
         String path = uri.getLastPathSegment();
+        if (path == null) {
+            return null;
+        }
 
         int periodIndex = path.lastIndexOf('.');
         if (periodIndex == -1 && uri.getPathSegments().size() > 1) {


### PR DESCRIPTION
`MediaSourceUtil.getExtension(Uri uri)` throws `NullPointerException` for url which ends with `/`.
For example `http://host.com/`