### PR TITLE
Bring progressPollRepeater setup inline with its cleanup

### DIFF
--- a/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoControls.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoControls.java
@@ -175,6 +175,23 @@ public abstract class VideoControls extends RelativeLayout {
     }
 
     @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+
+        //A poll used to periodically update the progress bar
+        progressPollRepeater.setRepeatListener(new Repeater.RepeatListener() {
+            @Override
+            public void onRepeat() {
+                updateProgress();
+            }
+        });
+
+        if (videoView != null && videoView.isPlaying()) {
+            updatePlaybackState(true);
+        }
+    }
+
+    @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
 
@@ -592,14 +609,6 @@ public abstract class VideoControls extends RelativeLayout {
 
         registerListeners();
         updateButtonDrawables();
-
-        //A poll used to periodically update the progress bar
-        progressPollRepeater.setRepeatListener(new Repeater.RepeatListener() {
-            @Override
-            public void onRepeat() {
-                updateProgress();
-            }
-        });
     }
 
     /**


### PR DESCRIPTION
This will also update the playback state when attached
and playing.

- [x] This pull request follows the coding standards

###### This PR changes:
 - Ensure the VideoControls state is preserved when using `VideoView#releaseOnDetachFromWindow = false` and the VideoView is detached and reattached.