### PR TITLE
Calling NativeVideoDelegate.openVideo when media player is not iddle …

### DIFF
--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeVideoDelegate.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeVideoDelegate.java
@@ -367,6 +367,7 @@ public class NativeVideoDelegate implements MediaController.MediaPlayerControl {
         currentBufferPercent = 0;
 
         try {
+            mediaPlayer.reset();
             mediaPlayer.setDataSource(context.getApplicationContext(), uri, headers);
             mediaPlayer.prepareAsync();
 


### PR DESCRIPTION
…throws IllegatlStateException

- [x] This pull request follows the coding standards

###### This PR changes:
 - Reset mediaPlayer in NativevVideoDelegate before calling setDataSource

Reference: http://stackoverflow.com/questions/7816551/java-lang-illegalstateexception-what-does-it-mean