### PR TITLE
[#444] Fixes onPrepared and getDuration

### DIFF
--- a/library/src/main/java/com/devbrackets/android/exomedia/core/audio/ExoAudioPlayer.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/audio/ExoAudioPlayer.java
@@ -73,6 +73,10 @@ public class ExoAudioPlayer implements AudioPlayerApi {
 
     @Override
     public void setDataSource(@Nullable Uri uri, @Nullable MediaSource mediaSource) {
+        //Makes sure the listeners get the onPrepared callback
+        listenerMux.setNotifiedPrepared(false);
+        exoMediaPlayer.seekTo(0);
+
         if (mediaSource != null) {
             exoMediaPlayer.setMediaSource(mediaSource);
             listenerMux.setNotifiedCompleted(false);
@@ -82,10 +86,6 @@ public class ExoAudioPlayer implements AudioPlayerApi {
         } else {
             exoMediaPlayer.setMediaSource(null);
         }
-
-        //Makes sure the listeners get the onPrepared callback
-        listenerMux.setNotifiedPrepared(false);
-        exoMediaPlayer.seekTo(0);
     }
 
     @Override

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoVideoDelegate.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoVideoDelegate.java
@@ -61,6 +61,10 @@ public class ExoVideoDelegate {
     }
 
     public void setVideoUri(@Nullable Uri uri, @Nullable MediaSource mediaSource) {
+        //Makes sure the listeners get the onPrepared callback
+        listenerMux.setNotifiedPrepared(false);
+        exoMediaPlayer.seekTo(0);
+
         if (mediaSource != null) {
             exoMediaPlayer.setMediaSource(mediaSource);
             listenerMux.setNotifiedCompleted(false);
@@ -70,10 +74,6 @@ public class ExoVideoDelegate {
         } else {
             exoMediaPlayer.setMediaSource(null);
         }
-
-        //Makes sure the listeners get the onPrepared callback
-        listenerMux.setNotifiedPrepared(false);
-        exoMediaPlayer.seekTo(0);
     }
 
     /**


### PR DESCRIPTION
###### Addresses issue #444
- [x] This pull request follows the coding standards

###### This PR changes:
 - Fixes `onPrepared()` getting called twice in some cases
 - Fixes `getDuration()` returning the unknown value when called from `onPrepared()` in some cases