### PR TITLE
Subtitles support for VideoView.

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     compile "com.google.android.exoplayer:exoplayer-dash:$exoPlayerVersion"
     compile "com.google.android.exoplayer:exoplayer-hls:$exoPlayerVersion"
     compile "com.google.android.exoplayer:exoplayer-smoothstreaming:$exoPlayerVersion"
+    compile "com.google.android.exoplayer:exoplayer-ui:$exoPlayerVersion"
 }
 
 android {

--- a/library/src/main/java/com/devbrackets/android/exomedia/ExoMedia.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/ExoMedia.java
@@ -37,6 +37,8 @@ public class ExoMedia {
         METADATA
     }
 
+    public static final int TRACK_GROUP_DISABLED  = -1;
+
     /**
      * Registers additional customized {@link com.google.android.exoplayer2.Renderer}s
      * that will be used by the {@link com.google.android.exoplayer2.source.MediaSource}s to

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/ListenerMux.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/ListenerMux.java
@@ -24,6 +24,7 @@ import android.support.annotation.Nullable;
 
 import com.devbrackets.android.exomedia.core.exception.NativeMediaPlaybackException;
 import com.devbrackets.android.exomedia.core.exoplayer.ExoMediaPlayer;
+import com.devbrackets.android.exomedia.core.listener.CaptionListener;
 import com.devbrackets.android.exomedia.core.listener.ExoPlayerListener;
 import com.devbrackets.android.exomedia.core.listener.MetadataListener;
 import com.devbrackets.android.exomedia.core.video.ClearableSurface;
@@ -34,8 +35,10 @@ import com.devbrackets.android.exomedia.listener.OnPreparedListener;
 import com.devbrackets.android.exomedia.listener.OnSeekCompletionListener;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.metadata.Metadata;
+import com.google.android.exoplayer2.text.Cue;
 
 import java.lang.ref.WeakReference;
+import java.util.List;
 
 /**
  * An internal Listener that implements the listeners for the {@link ExoMediaPlayer},
@@ -43,7 +46,7 @@ import java.lang.ref.WeakReference;
  * error listeners.
  */
 public class ListenerMux implements ExoPlayerListener, MediaPlayer.OnPreparedListener, MediaPlayer.OnCompletionListener, MediaPlayer.OnErrorListener,
-        MediaPlayer.OnBufferingUpdateListener, MediaPlayer.OnSeekCompleteListener, OnBufferUpdateListener, MetadataListener {
+        MediaPlayer.OnBufferingUpdateListener, MediaPlayer.OnSeekCompleteListener, OnBufferUpdateListener, MetadataListener, CaptionListener {
     //The amount of time the current position can be off the duration to call the onCompletion listener
     private static final long COMPLETED_DURATION_LEEWAY = 1000;
 
@@ -168,6 +171,11 @@ public class ListenerMux implements ExoPlayerListener, MediaPlayer.OnPreparedLis
     @Override
     public void onVideoSizeChanged(int width, int height, int unAppliedRotationDegrees, float pixelWidthHeightRatio) {
         muxNotifier.onVideoSizeChanged(width, height, unAppliedRotationDegrees, pixelWidthHeightRatio);
+    }
+
+    @Override
+    public void onCues(List<Cue> cues) {
+        muxNotifier.onCues(cues);
     }
 
     /**
@@ -322,6 +330,10 @@ public class ListenerMux implements ExoPlayerListener, MediaPlayer.OnPreparedLis
         }
 
         public void onPreviewImageStateChanged(boolean toVisible) {
+            //Purposefully left blank
+        }
+
+        public void onCues(List<Cue> cues) {
             //Purposefully left blank
         }
 

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/api/VideoViewApi.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/api/VideoViewApi.java
@@ -112,6 +112,10 @@ public interface VideoViewApi {
 
     void setTrack(ExoMedia.RendererType type, int trackIndex);
 
+    void setRendererTrackGroupIndex(ExoMedia.RendererType trackType, int trackGroupIndex);
+
+    int getRendererTrackGroupIndex(ExoMedia.RendererType trackType);
+
     /**
      * Retrieves a list of available tracks to select from.  Typically {@link #trackSelectionAvailable()}
      * should be called before this.

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/exoplayer/ExoMediaPlayer.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/exoplayer/ExoMediaPlayer.java
@@ -86,6 +86,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class ExoMediaPlayer implements ExoPlayer.EventListener {
     private static final String TAG = "ExoMediaPlayer";
+    public static final int RENDERER_INDEX_UNKNOWN = -1;
     private static final int BUFFER_REPEAT_DELAY = 1_000;
     private static final int WAKE_LOCK_TIMEOUT = 1_000;
 
@@ -336,6 +337,54 @@ public class ExoMediaPlayer implements ExoPlayer.EventListener {
         trackSelector.setSelectionOverride(exoPlayerTrackIndex, trackGroupArray, selectionOverride);
     }
 
+    public int getSelectedRendererTrackGroupIndex(@NonNull RendererType type) {
+        int exoPlayerRendererIndex = getExoPlayerRendererIndex(type);
+        if (exoPlayerRendererIndex == RENDERER_INDEX_UNKNOWN) {
+            // This RendererType of the renderer does not exists in the current media
+            return ExoMedia.TRACK_GROUP_DISABLED;
+        }
+        MappingTrackSelector.MappedTrackInfo mappedTrackInfo = trackSelector.getCurrentMappedTrackInfo();
+        TrackGroupArray trackGroupArray = mappedTrackInfo == null ? null : mappedTrackInfo.getTrackGroups(exoPlayerRendererIndex);
+        MappingTrackSelector.SelectionOverride selectionOverride = trackSelector.getSelectionOverride(exoPlayerRendererIndex, trackGroupArray);
+        if (selectionOverride == null || selectionOverride.length <= 0) {
+            return -1;
+        }
+
+        return selectionOverride.groupIndex;
+    }
+
+    public void setSelectedRendererTrackGroupIndex(@NonNull RendererType type, int groupIndex) {
+        // Retrieves the available tracks
+        int exoPlayerRendererIndex = getExoPlayerRendererIndex(type);
+        if (exoPlayerRendererIndex == RENDERER_INDEX_UNKNOWN) {
+            // This RendererType of the renderer does not exists in the current media
+            return;
+        }
+
+        if (groupIndex == ExoMedia.TRACK_GROUP_DISABLED) {
+            trackSelector.setRendererDisabled(exoPlayerRendererIndex, true);
+            trackSelector.clearSelectionOverrides(exoPlayerRendererIndex);
+            return;
+        }
+
+        MappingTrackSelector.MappedTrackInfo mappedTrackInfo = trackSelector.getCurrentMappedTrackInfo();
+        TrackGroupArray trackGroupArray = mappedTrackInfo == null ? null : mappedTrackInfo.getTrackGroups(exoPlayerRendererIndex);
+        if ((trackGroupArray == null) || (groupIndex >= trackGroupArray.length)) {
+            // Renderer exists in the current stream,
+            // but either the renderer does not have any tracks or
+            // the requested groupIndex is greater than the amount of track groups in this renderer.
+            return;
+        }
+
+        trackSelector.setRendererDisabled(exoPlayerRendererIndex, false);
+        // Creates the track selection override
+        MappingTrackSelector.SelectionOverride selectionOverride =
+                new MappingTrackSelector.SelectionOverride(new FixedTrackSelection.Factory(), groupIndex, new int[] {0});
+        // Specifies the renderer index in the current media stream
+        // and the trackGroupArray for which the override should be applied.
+        trackSelector.setSelectionOverride(exoPlayerRendererIndex, trackGroupArray, selectionOverride);
+    }
+
     public void setVolume(@FloatRange(from = 0.0, to = 1.0) float volume) {
         sendMessage(C.TRACK_TYPE_AUDIO, C.MSG_SET_VOLUME, volume);
     }
@@ -489,6 +538,19 @@ public class ExoMediaPlayer implements ExoPlayer.EventListener {
         }
 
         return C.TRACK_TYPE_UNKNOWN;
+    }
+
+    protected int getExoPlayerRendererIndex(@NonNull RendererType type) {
+        MappingTrackSelector.MappedTrackInfo mappedTrackInfo = trackSelector.getCurrentMappedTrackInfo();
+        if (mappedTrackInfo == null) {
+            return RENDERER_INDEX_UNKNOWN;
+        }
+        for (int i = 0; i < mappedTrackInfo.length; i++) {
+            if (player.getRendererType(i) == getExoPlayerTrackType(type)) {
+                return i;
+            }
+        }
+        return RENDERER_INDEX_UNKNOWN;
     }
 
     protected void sendMessage(int renderType, int messageType, Object message) {

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoSurfaceVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoSurfaceVideoView.java
@@ -149,6 +149,16 @@ public class ExoSurfaceVideoView extends ResizingSurfaceView implements VideoVie
         delegate.setTrack(trackType, trackIndex);
     }
 
+    @Override
+    public void setRendererTrackGroupIndex(ExoMedia.RendererType trackType, int trackGroupIndex) {
+        delegate.setRendererTrackGroupIndex(trackType, trackGroupIndex);
+    }
+
+    @Override
+    public int getRendererTrackGroupIndex(ExoMedia.RendererType trackType) {
+        return delegate.getRendererTrackGroupIndex(trackType);
+    }
+
     @Nullable
     @Override
     public Map<ExoMedia.RendererType, TrackGroupArray> getAvailableTracks() {

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoTextureVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoTextureVideoView.java
@@ -150,6 +150,16 @@ public class ExoTextureVideoView extends ResizingTextureView implements VideoVie
         delegate.setTrack(trackType, trackIndex);
     }
 
+    @Override
+    public void setRendererTrackGroupIndex(ExoMedia.RendererType trackType, int trackGroupIndex) {
+        delegate.setRendererTrackGroupIndex(trackType, trackGroupIndex);
+    }
+
+    @Override
+    public int getRendererTrackGroupIndex(ExoMedia.RendererType trackType) {
+        return delegate.getRendererTrackGroupIndex(trackType);
+    }
+
     @Nullable
     @Override
     public Map<ExoMedia.RendererType, TrackGroupArray> getAvailableTracks() {

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoVideoDelegate.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoVideoDelegate.java
@@ -27,6 +27,7 @@ import android.view.Surface;
 import com.devbrackets.android.exomedia.ExoMedia;
 import com.devbrackets.android.exomedia.core.ListenerMux;
 import com.devbrackets.android.exomedia.core.exoplayer.ExoMediaPlayer;
+import com.devbrackets.android.exomedia.core.listener.CaptionListener;
 import com.devbrackets.android.exomedia.core.listener.MetadataListener;
 import com.devbrackets.android.exomedia.core.video.ClearableSurface;
 import com.devbrackets.android.exomedia.listener.OnBufferUpdateListener;
@@ -34,7 +35,9 @@ import com.google.android.exoplayer2.drm.MediaDrmCallback;
 import com.google.android.exoplayer2.metadata.Metadata;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.text.Cue;
 
+import java.util.List;
 import java.util.Map;
 
 public class ExoVideoDelegate {
@@ -171,6 +174,14 @@ public class ExoVideoDelegate {
         exoMediaPlayer.setSelectedTrack(trackType, trackIndex);
     }
 
+    public void setRendererTrackGroupIndex(ExoMedia.RendererType trackType, int trackGroupIndex) {
+        exoMediaPlayer.setSelectedRendererTrackGroupIndex(trackType, trackGroupIndex);
+    }
+
+    public int getRendererTrackGroupIndex(ExoMedia.RendererType trackType) {
+        return exoMediaPlayer.getSelectedRendererTrackGroupIndex(trackType);
+    }
+
     @Nullable
     public Map<ExoMedia.RendererType, TrackGroupArray> getAvailableTracks() {
         return exoMediaPlayer.getAvailableTracks();
@@ -213,9 +224,10 @@ public class ExoVideoDelegate {
 
         exoMediaPlayer.setMetadataListener(internalListeners);
         exoMediaPlayer.setBufferUpdateListener(internalListeners);
+        exoMediaPlayer.setCaptionListener(internalListeners);
     }
 
-    protected class InternalListeners implements MetadataListener, OnBufferUpdateListener {
+    protected class InternalListeners implements MetadataListener, OnBufferUpdateListener, CaptionListener {
         @Override
         public void onMetadata(Metadata metadata) {
             listenerMux.onMetadata(metadata);
@@ -224,6 +236,11 @@ public class ExoVideoDelegate {
         @Override
         public void onBufferingUpdate(@IntRange(from = 0, to = 100) int percent) {
             listenerMux.onBufferingUpdate(percent);
+        }
+
+        @Override
+        public void onCues(List<Cue> cues) {
+            listenerMux.onCues(cues);
         }
     }
 }

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeSurfaceVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeSurfaceVideoView.java
@@ -187,6 +187,17 @@ public class NativeSurfaceVideoView extends ResizingSurfaceView implements Nativ
         //Purposefully left blank
     }
 
+    @Override
+    public void setRendererTrackGroupIndex(ExoMedia.RendererType trackType, int trackGroupIndex) {
+        //Purposefully left blank
+    }
+
+    @Override
+    public int getRendererTrackGroupIndex(ExoMedia.RendererType trackType) {
+        //Purposefully left blank
+        return ExoMedia.TRACK_GROUP_DISABLED;
+    }
+
     @Nullable
     @Override
     public Map<ExoMedia.RendererType, TrackGroupArray> getAvailableTracks() {

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeTextureVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeTextureVideoView.java
@@ -192,6 +192,17 @@ public class NativeTextureVideoView extends ResizingTextureView implements Nativ
         //Purposefully left blank
     }
 
+    @Override
+    public void setRendererTrackGroupIndex(ExoMedia.RendererType trackType, int trackGroupIndex) {
+        //Purposefully left blank
+    }
+
+    @Override
+    public int getRendererTrackGroupIndex(ExoMedia.RendererType trackType) {
+        //Purposefully left blank
+        return ExoMedia.TRACK_GROUP_DISABLED;
+    }
+
     @Nullable
     @Override
     public Map<ExoMedia.RendererType, TrackGroupArray> getAvailableTracks() {

--- a/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoView.java
@@ -58,7 +58,10 @@ import com.devbrackets.android.exomedia.util.StopWatch;
 import com.google.android.exoplayer2.drm.MediaDrmCallback;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.text.Cue;
+import com.google.android.exoplayer2.ui.SubtitleView;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -77,6 +80,7 @@ public class VideoView extends RelativeLayout {
     @Nullable
     protected VideoControls videoControls;
     protected ImageView previewImageView;
+    protected SubtitleView subtitleView;
 
     protected Uri videoUri;
     protected VideoViewApi videoViewImpl;
@@ -563,6 +567,26 @@ public class VideoView extends RelativeLayout {
     }
 
     /**
+     * Changes to the track with <code>trackGroupIndex</code> for the specified
+     * <code>trackType</code>
+     *
+     * @param trackType The type for the track to switch to the selected trackGroupIndex
+     * @param trackGroupIndex The index for the trackGroup to switch to
+     */
+    public void setRendererTrackGroupIndex(ExoMedia.RendererType trackType, int trackGroupIndex) {
+        videoViewImpl.setRendererTrackGroupIndex(trackType, trackGroupIndex);
+    }
+
+    /**
+     * Gets the selected trackGroup index for the renderer with the specified <code>trackType</code>
+     *
+     * @param trackType The type of the track to get the selected trackGroupIndex
+     */
+    public int getRendererTrackGroupIndex(ExoMedia.RendererType trackType) {
+        return videoViewImpl.getRendererTrackGroupIndex(trackType);
+    }
+
+    /**
      * Retrieves a list of available tracks to select from.  Typically {@link #trackSelectionAvailable()}
      * should be called before this.
      *
@@ -695,6 +719,7 @@ public class VideoView extends RelativeLayout {
 
         previewImageView = (ImageView) findViewById(R.id.exomedia_video_preview_image);
         videoViewImpl = (VideoViewApi) findViewById(R.id.exomedia_video_view);
+        subtitleView = (SubtitleView) findViewById(R.id.exo_subtitles);
 
         muxNotifier = new MuxNotifier();
         listenerMux = new ListenerMux(muxNotifier);
@@ -928,6 +953,10 @@ public class VideoView extends RelativeLayout {
             if (previewImageView != null) {
                 previewImageView.setVisibility(toVisible ? View.VISIBLE : View.GONE);
             }
+        }
+
+        public void onCues(List<Cue> cues) {
+            subtitleView.onCues(cues);
         }
     }
 

--- a/library/src/main/res/layout/exomedia_video_view_layout.xml
+++ b/library/src/main/res/layout/exomedia_video_view_layout.xml
@@ -17,4 +17,9 @@
         android:layout_height="match_parent"
         android:scaleType="centerCrop"
         tools:ignore="ContentDescription"/>
+
+    <com.google.android.exoplayer2.ui.SubtitleView
+        android:id="@+id/exo_subtitles"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
 </RelativeLayout>


### PR DESCRIPTION
Added the selection of the TrackGroup by specifying the groupIndex in the renderer's TrackGroupArray.

To enable subtitles, call:
videoView.setRendererTrackGroupIndex(ExoMedia.RendererType.CLOSED_CAPTION, 0);
where '0' is the groupIndex in the subtitles renderer tracks.

To disable:
videoView.setRendererTrackGroupIndex(ExoMedia.RendererType.CLOSED_CAPTION, ExoMedia.TRACK_GROUP_DISABLED);

To get the currently selected track group index (if any) in the specified renderer:
videoView.getRendererTrackGroupIndex(ExoMedia.RendererType.CLOSED_CAPTION);

###### Addresses issue #115.
- [ ] This pull request follows the coding standards

###### This PR changes:
 - 