### PR TITLE
Made the DataSourceFactoryProvider more permissive

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 dependencies {
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:26.0.0'
+    compile 'com.android.support:appcompat-v7:26.0.1'
     compile 'com.google.android.exoplayer:extension-okhttp:r2.5.1'
 
     // Image Loading

--- a/demo/src/main/java/com/devbrackets/android/exomediademo/App.java
+++ b/demo/src/main/java/com/devbrackets/android/exomediademo/App.java
@@ -9,8 +9,12 @@ import com.devbrackets.android.exomedia.ExoMedia;
 import com.devbrackets.android.exomediademo.manager.PlaylistManager;
 import com.google.android.exoplayer2.ext.okhttp.OkHttpDataSourceFactory;
 import com.google.android.exoplayer2.upstream.DataSource;
-import com.google.android.exoplayer2.upstream.HttpDataSource;
 import com.google.android.exoplayer2.upstream.TransferListener;
+import com.google.android.exoplayer2.upstream.cache.Cache;
+import com.google.android.exoplayer2.upstream.cache.CacheDataSource;
+import com.google.android.exoplayer2.upstream.cache.CacheDataSourceFactory;
+import com.google.android.exoplayer2.upstream.cache.LeastRecentlyUsedCacheEvictor;
+import com.google.android.exoplayer2.upstream.cache.SimpleCache;
 import com.squareup.leakcanary.LeakCanary;
 
 import okhttp3.OkHttpClient;
@@ -66,11 +70,16 @@ public class App extends Application {
     private void configureExoMedia() {
         // Registers the media sources to use the OkHttp client instead of the standard Apache one
         // Note: the OkHttpDataSourceFactory can be found in the ExoPlayer extension library `extension-okhttp`
-        ExoMedia.setHttpDataSourceFactoryProvider(new ExoMedia.HttpDataSourceFactoryProvider() {
+        ExoMedia.setDataSourceFactoryProvider(new ExoMedia.DataSourceFactoryProvider() {
             @NonNull
             @Override
-            public HttpDataSource.BaseFactory provide(@NonNull String userAgent, @Nullable TransferListener<? super DataSource> listener) {
-                return new OkHttpDataSourceFactory(new OkHttpClient(), userAgent, listener);
+            public DataSource.Factory provide(@NonNull String userAgent, @Nullable TransferListener<? super DataSource> listener) {
+                // Updates the network data source to use the OKHttp implementation
+                DataSource.Factory upstreamFactory = new OkHttpDataSourceFactory(new OkHttpClient(), userAgent, listener);
+
+                // Adds a cache around the upstreamFactory
+                Cache cache = new SimpleCache(getCacheDir(), new LeastRecentlyUsedCacheEvictor(50 * 1024 * 1024));
+                return new CacheDataSourceFactory(cache, upstreamFactory, CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR);
             }
         });
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -16,7 +16,7 @@ ext {
 
 dependencies {
     // Android
-    compile 'com.android.support:appcompat-v7:26.0.0'
+    compile 'com.android.support:appcompat-v7:26.0.1'
 
     // ExoPlayer
     compile "com.google.android.exoplayer:exoplayer-core:$exoPlayerVersion"

--- a/library/src/main/java/com/devbrackets/android/exomedia/ExoMedia.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/ExoMedia.java
@@ -25,9 +25,18 @@ import java.util.Map;
  * {@link com.google.android.exoplayer2.source.MediaSource}s
  */
 public class ExoMedia {
+    /**
+     * @deprecated Use {@link DataSourceFactoryProvider} instead
+     */
+    @Deprecated
     public interface HttpDataSourceFactoryProvider {
         @NonNull
         HttpDataSource.BaseFactory provide(@NonNull String userAgent, @Nullable TransferListener<? super DataSource> listener);
+    }
+
+    public interface DataSourceFactoryProvider {
+        @NonNull
+        DataSource.Factory provide(@NonNull String userAgent, @Nullable TransferListener<? super DataSource> listener);
     }
 
     public enum RendererType {
@@ -67,9 +76,23 @@ public class ExoMedia {
      * method.
      *
      * @param provider The provider to use for the {@link com.devbrackets.android.exomedia.core.source.builder.MediaSourceBuilder}s
+     * @deprecated Use {@link #setDataSourceFactoryProvider(DataSourceFactoryProvider)} instead as it is more permissive
      */
+    @Deprecated
     public static void setHttpDataSourceFactoryProvider(@Nullable HttpDataSourceFactoryProvider provider) {
         Data.httpDataSourceFactoryProvider = provider;
+    }
+
+    /**
+     * Specifies the provider to use when building {@link com.google.android.exoplayer2.upstream.DataSource.Factory}
+     * instances for use with the {@link com.devbrackets.android.exomedia.core.source.builder.MediaSourceBuilder}s. This will
+     * only be used for builders that haven't customized the {@link com.devbrackets.android.exomedia.core.source.builder.MediaSourceBuilder#buildDataSourceFactory(Context, String, TransferListener)}
+     * method.
+     *
+     * @param provider The provider to use for the {@link com.devbrackets.android.exomedia.core.source.builder.MediaSourceBuilder}s
+     */
+    public static void setDataSourceFactoryProvider(@Nullable DataSourceFactoryProvider provider) {
+        Data.dataSourceFactoryProvider = provider;
     }
 
     /**
@@ -92,7 +115,10 @@ public class ExoMedia {
         @NonNull
         public static final List<MediaSourceProvider.SourceTypeBuilder> sourceTypeBuilders = new ArrayList<>();
         @Nullable
+        @Deprecated
         public static volatile HttpDataSourceFactoryProvider httpDataSourceFactoryProvider;
+        @Nullable
+        public static volatile DataSourceFactoryProvider dataSourceFactoryProvider;
         @Nullable
         public static volatile LoadControl loadControl;
 

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/source/builder/MediaSourceBuilder.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/source/builder/MediaSourceBuilder.java
@@ -11,7 +11,6 @@ import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
-import com.google.android.exoplayer2.upstream.HttpDataSource;
 import com.google.android.exoplayer2.upstream.TransferListener;
 
 public abstract class MediaSourceBuilder {
@@ -21,8 +20,19 @@ public abstract class MediaSourceBuilder {
 
     @NonNull
     protected DataSource.Factory buildDataSourceFactory(@NonNull Context context, @NonNull String userAgent, @Nullable TransferListener<? super DataSource> listener) {
-        ExoMedia.HttpDataSourceFactoryProvider provider = ExoMedia.Data.httpDataSourceFactoryProvider;
-        HttpDataSource.BaseFactory dataSourceFactory = provider != null ? provider.provide(userAgent, listener) : new DefaultHttpDataSourceFactory(userAgent, listener);
+        ExoMedia.DataSourceFactoryProvider provider = ExoMedia.Data.dataSourceFactoryProvider;
+        DataSource.Factory dataSourceFactory = provider != null ? provider.provide(userAgent, listener) : null;
+
+        // Handles the deprecated httpDataSourceFactoryProvider
+        if (dataSourceFactory == null) {
+            ExoMedia.HttpDataSourceFactoryProvider httpProvider = ExoMedia.Data.httpDataSourceFactoryProvider;
+            dataSourceFactory = httpProvider != null ? httpProvider.provide(userAgent, listener) : null;
+        }
+
+        // If no factory was provided use the default one
+        if (dataSourceFactory == null) {
+            dataSourceFactory = new DefaultHttpDataSourceFactory(userAgent, listener);
+        }
 
         return new DefaultDataSourceFactory(context, listener, dataSourceFactory);
     }


### PR DESCRIPTION
###### Addresses issue (N/A)
- [x] This pull request follows the coding standards

###### This PR changes:
 - Deprecated the HttpDataSourceFactoryProvider in favor of the more permissive and aptly named DataSourceFactoryProvider to allow better support for things like cached data sources
