### PR TITLE
Fix aspect ratio

### DIFF
--- a/library/src/main/java/com/devbrackets/android/exomedia/core/api/VideoViewApi.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/api/VideoViewApi.java
@@ -143,7 +143,7 @@ public interface VideoViewApi {
 
     void setListenerMux(ListenerMux listenerMux);
 
-    void onVideoSizeChanged(int width, int height);
+    void onVideoSizeChanged(int width, int height, float pixelWidthHeightRatio);
 
     void setRepeatMode(@Player.RepeatMode int repeatMode);
 }

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoSurfaceVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoSurfaceVideoView.java
@@ -172,8 +172,8 @@ public class ExoSurfaceVideoView extends ResizingSurfaceView implements VideoVie
     }
 
     @Override
-    public void onVideoSizeChanged(int width, int height) {
-        if (updateVideoSize(width, height)) {
+    public void onVideoSizeChanged(int width, int height, float pixelWidthHeightRatio) {
+        if (updateVideoSize((int) (width * pixelWidthHeightRatio), height)) {
             requestLayout();
         }
     }

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoTextureVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoTextureVideoView.java
@@ -173,8 +173,8 @@ public class ExoTextureVideoView extends ResizingTextureView implements VideoVie
     }
 
     @Override
-    public void onVideoSizeChanged(int width, int height) {
-        if (updateVideoSize(width, height)) {
+    public void onVideoSizeChanged(int width, int height, float pixelWidthHeightRatio) {
+        if (updateVideoSize((int) (width * pixelWidthHeightRatio), height)) {
             requestLayout();
         }
     }

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeSurfaceVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeSurfaceVideoView.java
@@ -205,8 +205,8 @@ public class NativeSurfaceVideoView extends ResizingSurfaceView implements Nativ
     }
 
     @Override
-    public void onVideoSizeChanged(int width, int height) {
-        if (updateVideoSize(width, height)) {
+    public void onVideoSizeChanged(int width, int height, float pixelWidthHeightRatio) {
+        if (updateVideoSize((int) (width * pixelWidthHeightRatio), height)) {
             requestLayout();
         }
     }

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeTextureVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeTextureVideoView.java
@@ -210,8 +210,8 @@ public class NativeTextureVideoView extends ResizingTextureView implements Nativ
     }
 
     @Override
-    public void onVideoSizeChanged(int width, int height) {
-        if (updateVideoSize(width, height)) {
+    public void onVideoSizeChanged(int width, int height, float pixelWidthHeightRatio) {
+        if (updateVideoSize((int) (width * pixelWidthHeightRatio), height)) {
             requestLayout();
         }
     }

--- a/library/src/main/java/com/devbrackets/android/exomedia/listener/OnVideoSizeChangedListener.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/listener/OnVideoSizeChangedListener.java
@@ -15,5 +15,5 @@ public interface OnVideoSizeChangedListener {
      * @param intrinsicWidth The intrinsic (unscaled) width of the video currently in playback
      * @param intrinsicHeight The intrinsic (unscaled) height of the video currently in playback
      */
-    void onVideoSizeChanged(int intrinsicWidth, int intrinsicHeight);
+    void onVideoSizeChanged(int intrinsicWidth, int intrinsicHeight, float pixelWidthHeightRatio);
 }

--- a/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoView.java
@@ -965,10 +965,10 @@ public class VideoView extends RelativeLayout {
         public void onVideoSizeChanged(int width, int height, int unAppliedRotationDegrees, float pixelWidthHeightRatio) {
             //NOTE: Android 5.0+ will always have an unAppliedRotationDegrees of 0 (ExoPlayer already handles it)
             videoViewImpl.setVideoRotation(unAppliedRotationDegrees, false);
-            videoViewImpl.onVideoSizeChanged(width, height);
+            videoViewImpl.onVideoSizeChanged(width, height, pixelWidthHeightRatio);
 
             if (videoSizeChangedListener != null) {
-                videoSizeChangedListener.onVideoSizeChanged(width, height);
+                videoSizeChangedListener.onVideoSizeChanged(width, height, pixelWidthHeightRatio);
             }
         }
 


### PR DESCRIPTION
###### This PR changes:
 - Fix the aspect ratio when the pixel size is not an integer.

> In my project was observed when the video stream had a pixel size of 1x1.3 (approximately). Because of this, the rectangular image became square, since the player thought that the pixel size was 1x1.