### PR TITLE
[#454] Adds the ability to fetch window info (helps determine live/vod)

### DIFF
--- a/library/src/main/java/com/devbrackets/android/exomedia/AudioPlayer.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/AudioPlayer.java
@@ -28,6 +28,7 @@ import com.devbrackets.android.exomedia.core.api.AudioPlayerApi;
 import com.devbrackets.android.exomedia.core.audio.ExoAudioPlayer;
 import com.devbrackets.android.exomedia.core.audio.NativeAudioPlayer;
 import com.devbrackets.android.exomedia.core.exoplayer.ExoMediaPlayer;
+import com.devbrackets.android.exomedia.core.exoplayer.WindowInfo;
 import com.devbrackets.android.exomedia.core.listener.MetadataListener;
 import com.devbrackets.android.exomedia.listener.OnBufferUpdateListener;
 import com.devbrackets.android.exomedia.listener.OnCompletionListener;
@@ -326,6 +327,18 @@ public class AudioPlayer {
      */
     public int getBufferPercentage() {
         return audioPlayerImpl.getBufferedPercent();
+    }
+
+    /**
+     * Retrieves the information associated with the current {@link com.google.android.exoplayer2.Timeline.Window}
+     * used by the ExoPlayer backed implementation. When the {@link android.media.MediaPlayer} backed
+     * implementation is being used this will be null.
+     *
+     * @return The current Window information or null
+     */
+    @Nullable
+    public WindowInfo getWindowInfo() {
+        return audioPlayerImpl.getWindowInfo();
     }
 
     /**

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/api/AudioPlayerApi.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/api/AudioPlayerApi.java
@@ -21,10 +21,12 @@ import android.media.AudioManager;
 import android.net.Uri;
 import android.support.annotation.FloatRange;
 import android.support.annotation.IntRange;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.devbrackets.android.exomedia.ExoMedia;
 import com.devbrackets.android.exomedia.core.ListenerMux;
+import com.devbrackets.android.exomedia.core.exoplayer.WindowInfo;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.drm.MediaDrmCallback;
 import com.google.android.exoplayer2.source.MediaSource;
@@ -91,6 +93,9 @@ public interface AudioPlayerApi {
     @IntRange(from = 0, to = 100)
     int getBufferedPercent();
 
+    @Nullable
+    WindowInfo getWindowInfo();
+
     int getAudioSessionId();
 
     /**
@@ -116,7 +121,7 @@ public interface AudioPlayerApi {
 
     boolean trackSelectionAvailable();
 
-    void setTrack(ExoMedia.RendererType type, int trackIndex);
+    void setTrack(@NonNull ExoMedia.RendererType type, int trackIndex);
 
     /**
      * Retrieves a list of available tracks to select from.  Typically {@link #trackSelectionAvailable()}
@@ -137,7 +142,7 @@ public interface AudioPlayerApi {
 
     void seekTo(@IntRange(from = 0) long milliseconds);
 
-    void setWakeMode(Context context, int mode);
+    void setWakeMode(@NonNull Context context, int mode);
 
     void setListenerMux(ListenerMux listenerMux);
 

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/api/VideoViewApi.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/api/VideoViewApi.java
@@ -25,6 +25,7 @@ import android.view.View;
 
 import com.devbrackets.android.exomedia.ExoMedia;
 import com.devbrackets.android.exomedia.core.ListenerMux;
+import com.devbrackets.android.exomedia.core.exoplayer.WindowInfo;
 import com.devbrackets.android.exomedia.core.video.scale.ScaleType;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.drm.MediaDrmCallback;
@@ -104,6 +105,9 @@ public interface VideoViewApi {
     @IntRange(from = 0, to = 100)
     int getBufferedPercent();
 
+    @Nullable
+    WindowInfo getWindowInfo();
+
     /**
      * Sets the playback speed for this MediaPlayer.
      *
@@ -116,7 +120,7 @@ public interface VideoViewApi {
 
     boolean trackSelectionAvailable();
 
-    void setTrack(ExoMedia.RendererType type, int trackIndex);
+    void setTrack(@NonNull ExoMedia.RendererType type, int trackIndex);
 
     /**
      * Retrieves a list of available tracks to select from.  Typically {@link #trackSelectionAvailable()}
@@ -138,6 +142,7 @@ public interface VideoViewApi {
 
     void setScaleType(@NonNull ScaleType scaleType);
 
+    @NonNull
     ScaleType getScaleType();
 
     void setMeasureBasedOnAspectRatioEnabled(boolean doNotMeasureBasedOnAspectRatio);

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/audio/ExoAudioPlayer.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/audio/ExoAudioPlayer.java
@@ -29,6 +29,7 @@ import com.devbrackets.android.exomedia.ExoMedia;
 import com.devbrackets.android.exomedia.core.ListenerMux;
 import com.devbrackets.android.exomedia.core.api.AudioPlayerApi;
 import com.devbrackets.android.exomedia.core.exoplayer.ExoMediaPlayer;
+import com.devbrackets.android.exomedia.core.exoplayer.WindowInfo;
 import com.devbrackets.android.exomedia.core.listener.MetadataListener;
 import com.devbrackets.android.exomedia.listener.OnBufferUpdateListener;
 import com.google.android.exoplayer2.Player;
@@ -187,6 +188,12 @@ public class ExoAudioPlayer implements AudioPlayerApi {
         return exoMediaPlayer.getBufferedPercentage();
     }
 
+    @Nullable
+    @Override
+    public WindowInfo getWindowInfo() {
+        return exoMediaPlayer.getWindowInfo();
+    }
+
     @Override
     public void release() {
         exoMediaPlayer.release();
@@ -213,7 +220,7 @@ public class ExoAudioPlayer implements AudioPlayerApi {
     }
 
     @Override
-    public void setWakeMode(Context context, int mode) {
+    public void setWakeMode(@NonNull Context context, int mode) {
         exoMediaPlayer.setWakeMode(context, mode);
     }
 
@@ -223,7 +230,7 @@ public class ExoAudioPlayer implements AudioPlayerApi {
     }
 
     @Override
-    public void setTrack(ExoMedia.RendererType type, int trackIndex) {
+    public void setTrack(@NonNull ExoMedia.RendererType type, int trackIndex) {
         exoMediaPlayer.setSelectedTrack(type, trackIndex);
     }
 

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/audio/NativeAudioPlayer.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/audio/NativeAudioPlayer.java
@@ -30,6 +30,7 @@ import android.util.Log;
 import com.devbrackets.android.exomedia.ExoMedia;
 import com.devbrackets.android.exomedia.core.ListenerMux;
 import com.devbrackets.android.exomedia.core.api.AudioPlayerApi;
+import com.devbrackets.android.exomedia.core.exoplayer.WindowInfo;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.drm.MediaDrmCallback;
 import com.google.android.exoplayer2.source.MediaSource;
@@ -198,6 +199,12 @@ public class NativeAudioPlayer implements AudioPlayerApi {
         return currentBufferPercent;
     }
 
+    @Nullable
+    @Override
+    public WindowInfo getWindowInfo() {
+        return null;
+    }
+
     @Override
     public void release() {
         mediaPlayer.release();
@@ -238,7 +245,7 @@ public class NativeAudioPlayer implements AudioPlayerApi {
     }
 
     @Override
-    public void setWakeMode(Context context, int mode) {
+    public void setWakeMode(@NonNull Context context, int mode) {
         mediaPlayer.setWakeMode(context, mode);
     }
 
@@ -248,7 +255,7 @@ public class NativeAudioPlayer implements AudioPlayerApi {
     }
 
     @Override
-    public void setTrack(ExoMedia.RendererType trackType, int trackIndex) {
+    public void setTrack(@NonNull ExoMedia.RendererType trackType, int trackIndex) {
         //Purposefully left blank
     }
 

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/exoplayer/ExoMediaPlayer.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/exoplayer/ExoMediaPlayer.java
@@ -52,6 +52,7 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.PlayerMessage;
 import com.google.android.exoplayer2.Renderer;
+import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.audio.AudioAttributes;
 import com.google.android.exoplayer2.audio.AudioRendererEventListener;
 import com.google.android.exoplayer2.decoder.DecoderCounters;
@@ -313,7 +314,7 @@ public class ExoMediaPlayer extends Player.DefaultEventListener {
 
         // Creates the track selection override
         int[] tracks = new int[] {index};
-        TrackSelection.Factory factory = tracks.length == 1 ? new FixedTrackSelection.Factory() : adaptiveTrackSelectionFactory;
+        TrackSelection.Factory factory = new FixedTrackSelection.Factory();
         MappingTrackSelector.SelectionOverride selectionOverride = new MappingTrackSelector.SelectionOverride(factory, exoPlayerTrackIndex, tracks);
 
         // Specifies the correct track to use
@@ -445,6 +446,24 @@ public class ExoMediaPlayer extends Player.DefaultEventListener {
 
     public int getBufferedPercentage() {
         return player.getBufferedPercentage();
+    }
+
+    @Nullable
+    public WindowInfo getWindowInfo() {
+        Timeline timeline = player.getCurrentTimeline();
+        if (timeline.isEmpty()) {
+            return null;
+        }
+
+        int currentWindowIndex = player.getCurrentWindowIndex();
+        Timeline.Window currentWindow = timeline.getWindow(currentWindowIndex, new Timeline.Window());
+
+        return new WindowInfo(
+                player.getPreviousWindowIndex(),
+                currentWindowIndex,
+                player.getNextWindowIndex(),
+                currentWindow
+        );
     }
 
     public boolean getPlayWhenReady() {

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/exoplayer/WindowInfo.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/exoplayer/WindowInfo.java
@@ -1,0 +1,21 @@
+package com.devbrackets.android.exomedia.core.exoplayer;
+
+import android.support.annotation.NonNull;
+
+import com.google.android.exoplayer2.Timeline;
+
+public class WindowInfo {
+    public final int previousWindowIndex;
+    public final int currentWindowIndex;
+    public final int nextWindowIndex;
+
+    @NonNull
+    public final Timeline.Window currentWindow;
+
+    public WindowInfo(int previousWindowIndex, int currentWindowIndex, int nextWindowIndex, @NonNull Timeline.Window currentWindow) {
+        this.previousWindowIndex = previousWindowIndex;
+        this.currentWindowIndex = currentWindowIndex;
+        this.nextWindowIndex = nextWindowIndex;
+        this.currentWindow = currentWindow;
+    }
+}

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoSurfaceVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoSurfaceVideoView.java
@@ -30,6 +30,7 @@ import android.view.SurfaceHolder;
 import com.devbrackets.android.exomedia.ExoMedia;
 import com.devbrackets.android.exomedia.core.ListenerMux;
 import com.devbrackets.android.exomedia.core.api.VideoViewApi;
+import com.devbrackets.android.exomedia.core.exoplayer.WindowInfo;
 import com.devbrackets.android.exomedia.core.video.ResizingSurfaceView;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.drm.MediaDrmCallback;
@@ -141,6 +142,12 @@ public class ExoSurfaceVideoView extends ResizingSurfaceView implements VideoVie
         return delegate.getBufferedPercent();
     }
 
+    @Nullable
+    @Override
+    public WindowInfo getWindowInfo() {
+        return delegate.getWindowInfo();
+    }
+
     @Override
     public boolean setPlaybackSpeed(float speed) {
         return delegate.setPlaybackSpeed(speed);
@@ -157,7 +164,7 @@ public class ExoSurfaceVideoView extends ResizingSurfaceView implements VideoVie
     }
 
     @Override
-    public void setTrack(ExoMedia.RendererType trackType, int trackIndex) {
+    public void setTrack(@NonNull ExoMedia.RendererType trackType, int trackIndex) {
         delegate.setTrack(trackType, trackIndex);
     }
 

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoTextureVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoTextureVideoView.java
@@ -31,6 +31,7 @@ import android.view.Surface;
 import com.devbrackets.android.exomedia.ExoMedia;
 import com.devbrackets.android.exomedia.core.ListenerMux;
 import com.devbrackets.android.exomedia.core.api.VideoViewApi;
+import com.devbrackets.android.exomedia.core.exoplayer.WindowInfo;
 import com.devbrackets.android.exomedia.core.video.ResizingTextureView;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.drm.MediaDrmCallback;
@@ -142,6 +143,12 @@ public class ExoTextureVideoView extends ResizingTextureView implements VideoVie
         return delegate.getBufferedPercent();
     }
 
+    @Nullable
+    @Override
+    public WindowInfo getWindowInfo() {
+        return delegate.getWindowInfo();
+    }
+
     @Override
     public boolean setPlaybackSpeed(float speed) {
         return delegate.setPlaybackSpeed(speed);
@@ -158,7 +165,7 @@ public class ExoTextureVideoView extends ResizingTextureView implements VideoVie
     }
 
     @Override
-    public void setTrack(ExoMedia.RendererType trackType, int trackIndex) {
+    public void setTrack(@NonNull ExoMedia.RendererType trackType, int trackIndex) {
         delegate.setTrack(trackType, trackIndex);
     }
 

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoVideoDelegate.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/exo/ExoVideoDelegate.java
@@ -27,6 +27,7 @@ import android.view.Surface;
 import com.devbrackets.android.exomedia.ExoMedia;
 import com.devbrackets.android.exomedia.core.ListenerMux;
 import com.devbrackets.android.exomedia.core.exoplayer.ExoMediaPlayer;
+import com.devbrackets.android.exomedia.core.exoplayer.WindowInfo;
 import com.devbrackets.android.exomedia.core.listener.MetadataListener;
 import com.devbrackets.android.exomedia.core.video.ClearableSurface;
 import com.devbrackets.android.exomedia.listener.OnBufferUpdateListener;
@@ -166,6 +167,11 @@ public class ExoVideoDelegate {
 
     public int getBufferedPercent() {
         return exoMediaPlayer.getBufferedPercentage();
+    }
+
+    @Nullable
+    public WindowInfo getWindowInfo() {
+        return exoMediaPlayer.getWindowInfo();
     }
 
     public boolean trackSelectionAvailable() {

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeSurfaceVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeSurfaceVideoView.java
@@ -32,6 +32,7 @@ import android.widget.MediaController;
 import com.devbrackets.android.exomedia.ExoMedia;
 import com.devbrackets.android.exomedia.core.ListenerMux;
 import com.devbrackets.android.exomedia.core.api.VideoViewApi;
+import com.devbrackets.android.exomedia.core.exoplayer.WindowInfo;
 import com.devbrackets.android.exomedia.core.video.ResizingSurfaceView;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.drm.MediaDrmCallback;
@@ -158,6 +159,12 @@ public class NativeSurfaceVideoView extends ResizingSurfaceView implements Nativ
         return delegate.getBufferPercentage();
     }
 
+    @Nullable
+    @Override
+    public WindowInfo getWindowInfo() {
+        return delegate.getWindowInfo();
+    }
+
     /**
      * If the video has completed playback, calling {@code restart} will seek to the beginning of the video, and play it.
      *
@@ -194,7 +201,7 @@ public class NativeSurfaceVideoView extends ResizingSurfaceView implements Nativ
     }
 
     @Override
-    public void setTrack(ExoMedia.RendererType trackType, int trackIndex) {
+    public void setTrack(@NonNull ExoMedia.RendererType trackType, int trackIndex) {
         //Purposefully left blank
     }
 

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeTextureVideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeTextureVideoView.java
@@ -33,6 +33,7 @@ import android.widget.MediaController;
 import com.devbrackets.android.exomedia.ExoMedia;
 import com.devbrackets.android.exomedia.core.ListenerMux;
 import com.devbrackets.android.exomedia.core.api.VideoViewApi;
+import com.devbrackets.android.exomedia.core.exoplayer.WindowInfo;
 import com.devbrackets.android.exomedia.core.video.ResizingTextureView;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.drm.MediaDrmCallback;
@@ -163,6 +164,12 @@ public class NativeTextureVideoView extends ResizingTextureView implements Nativ
         return delegate.getBufferPercentage();
     }
 
+    @Nullable
+    @Override
+    public WindowInfo getWindowInfo() {
+        return delegate.getWindowInfo();
+    }
+
     /**
      * If the video has completed playback, calling {@code restart} will seek to the beginning of the video, and play it.
      *
@@ -199,7 +206,7 @@ public class NativeTextureVideoView extends ResizingTextureView implements Nativ
     }
 
     @Override
-    public void setTrack(ExoMedia.RendererType trackType, int trackIndex) {
+    public void setTrack(@NonNull ExoMedia.RendererType trackType, int trackIndex) {
         //Purposefully left blank
     }
 

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeVideoDelegate.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/video/mp/NativeVideoDelegate.java
@@ -29,6 +29,7 @@ import android.util.Log;
 import android.view.Surface;
 
 import com.devbrackets.android.exomedia.core.ListenerMux;
+import com.devbrackets.android.exomedia.core.exoplayer.WindowInfo;
 import com.devbrackets.android.exomedia.core.video.ClearableSurface;
 
 import java.io.IOException;
@@ -167,6 +168,11 @@ public class NativeVideoDelegate {
         }
 
         return 0;
+    }
+
+    @Nullable
+    public WindowInfo getWindowInfo() {
+        return null;
     }
 
     public boolean setPlaybackSpeed(float speed) {

--- a/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoView.java
@@ -44,6 +44,7 @@ import com.devbrackets.android.exomedia.R;
 import com.devbrackets.android.exomedia.core.ListenerMux;
 import com.devbrackets.android.exomedia.core.api.VideoViewApi;
 import com.devbrackets.android.exomedia.core.exoplayer.ExoMediaPlayer;
+import com.devbrackets.android.exomedia.core.exoplayer.WindowInfo;
 import com.devbrackets.android.exomedia.core.listener.MetadataListener;
 import com.devbrackets.android.exomedia.core.video.exo.ExoTextureVideoView;
 import com.devbrackets.android.exomedia.core.video.mp.NativeTextureVideoView;
@@ -596,6 +597,18 @@ public class VideoView extends RelativeLayout {
      */
     public int getBufferPercentage() {
         return videoViewImpl.getBufferedPercent();
+    }
+
+    /**
+     * Retrieves the information associated with the current {@link com.google.android.exoplayer2.Timeline.Window}
+     * used by the ExoPlayer backed implementation. When the {@link android.media.MediaPlayer} backed
+     * implementation is being used this will be null.
+     *
+     * @return The current Window information or null
+     */
+    @Nullable
+    public WindowInfo getWindowInfo() {
+        return videoViewImpl.getWindowInfo();
     }
 
     /**


### PR DESCRIPTION
###### Addresses issue #454 
- [x] This pull request follows the coding standards

###### This PR changes:
 - Updated the VideoView and AudioPlayer with the ability to get Timeline.Window information to help determine live/vod differences