### PR TITLE
#541 fix exo player track index calculation for the exo media rendere…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.novoda:bintray-release:0.8.1'
     }
 }


### PR DESCRIPTION
…r type such as it is not a constant value

###### Addresses issue #.
- [ ] This pull request follows the coding standards

###### This PR changes:
 - Fixes exo player track index calculation. The current code assumes it is constant for every RendererType. But some video files may contain few tracks of the same type (See test5.mkv from https://www.matroska.org/downloads/test_w1.html) and this breaks the track info inside ExoMedia.