### PR TITLE
issue#663: Fix leanback controls show/hide animation during trickplay

### DIFF
--- a/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoControlsLeanback.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoControlsLeanback.java
@@ -293,6 +293,7 @@ public class VideoControlsLeanback extends VideoControls {
      */
     protected void performSeek(long seekToTime) {
         if (seekListener == null || !seekListener.onSeekEnded(seekToTime)) {
+            show();
             internalListener.onSeekEnded(seekToTime);
         }
     }


### PR DESCRIPTION
###### Addresses issue #663 
- [x] This pull request follows the coding standards

###### This PR changes:
 - Seeking in leanback performs a `hideDelayed()` inside of `onSeekEnded()` in the parent `VideoControls`. However, the controls are never shown before this, so the hide ends up looking like a quick flash followed by the fade out. This change makes it so that prior to seeking the controls are shown as desired.