### PR TITLE
Update ExoPlayer, make use of ExoPlayer's AudioFocusManager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-rc01'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }
 }
@@ -17,6 +17,6 @@ allprojects {
 }
 
 ext {
-    exoPlayerVersion = "2.9.1"
+    exoPlayerVersion = "2.9.6"
     supportLibVersion = "28.0.0"
 }

--- a/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoView.java
@@ -368,7 +368,7 @@ public class VideoView extends RelativeLayout {
      * with ExoPlayers's AudioFocusManager.
      */
     @Deprecated
-    void setHandleAudioFocus(boolean handleAudioFocus) {
+    public void setHandleAudioFocus(boolean handleAudioFocus) {
     }
 
     /**

--- a/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoView.java
@@ -365,7 +365,9 @@ public class VideoView extends RelativeLayout {
 
     /**
      * This function is a no-op. Audiofocus is handled automatically
-     * with ExoPlayers's AudioFocusManager.
+     * with ExoPlayers's AudioFocusManager in ExoMediaPlayer
+     * @see com.google.android.exoplayer2.audio.AudioFocusManager
+     * @see com.devbrackets.android.exomedia.core.exoplayer.ExoMediaPlayer
      */
     @Deprecated
     public void setHandleAudioFocus(boolean handleAudioFocus) {
@@ -420,23 +422,23 @@ public class VideoView extends RelativeLayout {
      * If a video is currently in playback, it will be paused
      */
     public void pause() {
-        pause(false);
-    }
-
-    /**
-     * Pauses the current video in playback, only abandoning the audio focus if
-     * <code>transientFocusLoss</code> is <code>false</code>. Calling {@link #pause()} should
-     * be used in most cases unless the audio focus is being handled manually
-     *
-     * @param transientFocusLoss <code>true</code> if the pause is temporary and the audio focus should be retained
-     */
-    public void pause(boolean transientFocusLoss) {
         videoViewImpl.pause();
         setKeepScreenOn(false);
 
         if (videoControls != null) {
             videoControls.updatePlaybackState(false);
         }
+    }
+
+    /**
+     * Call pause() instead. Audiofocus is handled automatically
+     * with ExoPlayers's AudioFocusManager in ExoMediaPlayer
+     * @see com.google.android.exoplayer2.audio.AudioFocusManager
+     * @see com.devbrackets.android.exomedia.core.exoplayer.ExoMediaPlayer
+     */
+    @Deprecated
+    public void pause(boolean transientFocusLoss) {
+        pause();
     }
 
     /**

--- a/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoView.java
@@ -21,7 +21,6 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
-import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.DrawableRes;
@@ -86,8 +85,6 @@ public class VideoView extends RelativeLayout {
     protected Uri videoUri;
     protected VideoViewApi videoViewImpl;
     protected DeviceUtil deviceUtil = new DeviceUtil();
-
-    protected AudioManager audioManager;
 
     protected long positionOffset = 0;
     protected long overriddenDuration = -1;
@@ -849,9 +846,6 @@ public class VideoView extends RelativeLayout {
         if (isInEditMode()) {
             return;
         }
-
-        audioManager = (AudioManager) context.getApplicationContext().getSystemService(Context.AUDIO_SERVICE);
-
         AttributeContainer attributeContainer = new AttributeContainer(context, attrs);
         initView(context, attributeContainer);
         postInit(attributeContainer);


### PR DESCRIPTION
###### Addresses issue #.
- [x] This pull request follows the coding standards

addresses #493 
###### This PR changes:
 - Update ExoPlayer to 2.9.6
 - Removed AudioFocusHelper
 - make use of ExoPlayer's AudioFocusManager
   for implementation I have oriented myself on the use of AudioFocusManager in ExoPlayer's SimpleExoPlayer

Current drawback and open for discussion: I have had to make setHandleAudioFocus in VideoView to a no-op, as AudioFocus is not handled within this class anymore and I don't know how to inform the ExoMediaPlayer instance from there. Per default it was enabled anyway.