### PR TITLE
Update ExoPlayer, make use of ExoPlayer's AudioFocusManager

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-rc01'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }
 }
@@ -17,6 +17,6 @@ allprojects {
 }
 
 ext {
-    exoPlayerVersion = "2.9.1"
+    exoPlayerVersion = "2.9.6"
     supportLibVersion = "28.0.0"
 }

--- a/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoView.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/ui/widget/VideoView.java
@@ -377,10 +377,8 @@ public class VideoView extends RelativeLayout {
      * @param handleAudioFocus {@code true} to handle audio focus
      */
     public void setHandleAudioFocus(boolean handleAudioFocus) {
-        if(audioFocusHelper != null) {
-            audioFocusHelper.abandonFocus();
-        }
         if(Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+            audioFocusHelper.abandonFocus();
             this.handleAudioFocus = handleAudioFocus;
         }
     }


### PR DESCRIPTION
###### Addresses issue #493
- [X] This pull request follows the coding standards

###### This PR changes:
 - Update ExoPlayer to 2.9.6
 - Use AudioFocusHelper only on devices prior to JellyBean
 - make use of ExoPlayer's AudioFocusManager on all devices that use ExoPlayer (JellyBean and newer)
   for implementation I have oriented myself on the use of AudioFocusManager in ExoPlayer's SimpleExoPlayer

Current drawback and open for discussion: setHandleAudioFocus in VideoView does nothing on devices with JellyBean or newer, as AudioFocus is not handled within this class for those devices anymore and I don't know how to inform the ExoMediaPlayer instance from there. Per default it was enabled anyway.