### PR TITLE
Update ExoPlayer to 2.9.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-rc01'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }
 }
@@ -17,6 +17,6 @@ allprojects {
 }
 
 ext {
-    exoPlayerVersion = "2.9.1"
+    exoPlayerVersion = "2.9.6"
     supportLibVersion = "28.0.0"
 }


### PR DESCRIPTION
as in my previous pull requests, updating to 2.9.6 does not include any breaking changes and can "just be done".
Updating gradle is required as it is the new minimum build version required by the current Android Studio version.
I have build the demo with these new settings without any issues, so it should be safe to merge.

###### Addresses issue #.
- [X] This pull request follows the coding standards

###### This PR changes:
 - ExoPlayer 2.9.1 -> 2.9.6
 - gradle:3.3.0-rc01 -> 3.3.2