### PR TITLE
VideoPlayerActivity resume from background fix

### DIFF
--- a/demo/src/main/kotlin/com/devbrackets/android/exomediademo/ui/activity/VideoPlayerActivity.kt
+++ b/demo/src/main/kotlin/com/devbrackets/android/exomediademo/ui/activity/VideoPlayerActivity.kt
@@ -43,14 +43,17 @@ open class VideoPlayerActivity : Activity(), VideoControlsSeekListener {
 
     override fun onStop() {
         super.onStop()
-        playlistManager.removeVideoApi(videoApi)
-        playlistManager.invokeStop()
+        if (videoApi.isPlaying) {
+            playlistManager.invokePausePlay()
+        }
     }
 
     override fun onDestroy() {
         super.onDestroy()
+        playlistManager.removeVideoApi(videoApi)
         playlistManager.invokeStop()
     }
+
 
     override fun onSeekStarted(): Boolean {
         playlistManager.invokeSeekStarted()


### PR DESCRIPTION
###### Addresses issue #.
- [x] This pull request follows the coding standards

###### This PR changes:
 - When you are playing video and move your app to background and then resume it then video got stuck, even all controllers were freeze
- I've moved playlistManager.removeVideoApi(videoApi) and  playlistManager.invokeStop() from onStop to onDestroy, so it won't destroy when you are moving app to background