### PR TITLE
Update ExoPlayer to 2.11.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }
 }
@@ -17,6 +17,6 @@ allprojects {
 }
 
 ext {
-    exoPlayerVersion = "2.9.6"
+    exoPlayerVersion = "2.11.1"
     supportLibVersion = "28.0.0"
 }

--- a/demo/src/main/kotlin/com/devbrackets/android/exomediademo/App.kt
+++ b/demo/src/main/kotlin/com/devbrackets/android/exomediademo/App.kt
@@ -3,6 +3,8 @@ package com.devbrackets.android.exomediademo
 import android.app.Application
 import com.devbrackets.android.exomedia.ExoMedia
 import com.devbrackets.android.exomediademo.manager.PlaylistManager
+import com.google.android.exoplayer2.database.DatabaseProvider
+import com.google.android.exoplayer2.database.ExoDatabaseProvider
 import com.google.android.exoplayer2.ext.okhttp.OkHttpDataSourceFactory
 import com.google.android.exoplayer2.upstream.DataSource
 import com.google.android.exoplayer2.upstream.TransferListener
@@ -16,6 +18,7 @@ import java.io.File
 
 class App : Application() {
     val playlistManager: PlaylistManager by lazy { PlaylistManager(this) }
+    private lateinit var databaseProvider: DatabaseProvider
 
     override fun onCreate() {
         super.onCreate()
@@ -25,6 +28,7 @@ class App : Application() {
     }
 
     private fun configureExoMedia() {
+        databaseProvider = ExoDatabaseProvider(this)
         // Registers the media sources to use the OkHttp client instead of the standard Apache one
         // Note: the OkHttpDataSourceFactory can be found in the ExoPlayer extension library `extension-okhttp`
         ExoMedia.setDataSourceFactoryProvider(object : ExoMedia.DataSourceFactoryProvider {
@@ -36,7 +40,7 @@ class App : Application() {
                     val upstreamFactory = OkHttpDataSourceFactory(OkHttpClient(), userAgent, listener)
 
                     // Adds a cache around the upstreamFactory
-                    val cache = SimpleCache(File(cacheDir, "ExoMediaCache"), LeastRecentlyUsedCacheEvictor((50 * 1024 * 1024).toLong()))
+                    val cache = SimpleCache(File(cacheDir, "ExoMediaCache"), LeastRecentlyUsedCacheEvictor((50 * 1024 * 1024).toLong()), databaseProvider)
                     instance = CacheDataSourceFactory(cache, upstreamFactory, CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
                 }
 

--- a/demo/src/main/kotlin/com/devbrackets/android/exomediademo/data/Samples.kt
+++ b/demo/src/main/kotlin/com/devbrackets/android/exomediademo/data/Samples.kt
@@ -19,15 +19,15 @@ object Samples {
 
         //Video items
         videoSamples = ArrayList()
-        videoSamples.add(Sample("FLV - Big Buck Bunny by Blender", "http://vod.leasewebcdn.com/bbb.flv?ri=1024&rs=150&start=0"))
+        videoSamples.add(Sample("FLV - Big Buck Bunny by Blender", "https://vod.leasewebcdn.com/bbb.flv?ri=1024&rs=150&start=0"))
         videoSamples.add(Sample("HLS - ArtBeats", "http://cdn-fms.rbs.com.br/vod/hls_sample1_manifest.m3u8"))
         videoSamples.add(Sample("HLS - Sintel by Blender", "https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"))
-        videoSamples.add(Sample("MKV - Android Screens", "http://storage.googleapis.com/exoplayer-test-media-1/mkv/android-screens-lavf-56.36.100-aac-avc-main-1280x720.mkv"))
-        videoSamples.add(Sample("MP4 (VP9) - Google Glass", "http://demos.webmproject.org/exoplayer/glass.mp4"))
+        videoSamples.add(Sample("MKV - Android Screens", "https://storage.googleapis.com/exoplayer-test-media-1/mkv/android-screens-lavf-56.36.100-aac-avc-main-1280x720.mkv"))
+        videoSamples.add(Sample("MP4 (VP9) - Google Glass", "https://demos.webmproject.org/exoplayer/glass.mp4"))
         videoSamples.add(Sample("MPEG DASH - Sintel by Blender", "https://bitdash-a.akamaihd.net/content/sintel/sintel.mpd"))
         videoSamples.add(Sample("MPEG DASH - Big Buck Bunny by Blender, Live", "https://wowzaec2demo.streamlock.net/live/bigbuckbunny/manifest_mpm4sav_mvtime.mpd"))
-        videoSamples.add(Sample("Smooth Stream - Caminandes: Llama Drama by Blender", "http://amssamples.streaming.mediaservices.windows.net/634cd01c-6822-4630-8444-8dd6279f94c6/CaminandesLlamaDrama4K.ism/manifest"))
-        videoSamples.add(Sample("Smooth Stream - Tears of Steel Teaser by Blender", "http://amssamples.streaming.mediaservices.windows.net/3d7eaff9-39fa-442f-81cc-f2ea7db1797e/TearsOfSteelTeaser.ism/manifest"))
+        videoSamples.add(Sample("Smooth Stream - Caminandes: Llama Drama by Blender", "https://amssamples.streaming.mediaservices.windows.net/634cd01c-6822-4630-8444-8dd6279f94c6/CaminandesLlamaDrama4K.ism/manifest"))
+        videoSamples.add(Sample("Smooth Stream - Tears of Steel Teaser by Blender", "https://amssamples.streaming.mediaservices.windows.net/3d7eaff9-39fa-442f-81cc-f2ea7db1797e/TearsOfSteelTeaser.ism/manifest"))
         videoSamples.add(Sample("WEBM - Big Buck Bunny", "http://dl1.webmfiles.org/big-buck-bunny_trailer.webm"))
         videoSamples.add(Sample("WEBM - Elephants Dream", "http://dl1.webmfiles.org/elephants-dream.webm"))
     }

--- a/demo/src/main/kotlin/com/devbrackets/android/exomediademo/ui/subtitle/SubtitlePainter.kt
+++ b/demo/src/main/kotlin/com/devbrackets/android/exomediademo/ui/subtitle/SubtitlePainter.kt
@@ -171,7 +171,7 @@ internal class SubtitlePainter(context: Context) {
             else
                 style.windowColor
         }
-        if (areCharSequencesEqual(this.cueText, cue.text)
+        if (areCharSequencesEqual(this.cueText, cue.text ?: "")
             && Util.areEqual(this.cueTextAlignment, cue.textAlignment)
             && this.cueBitmap == cue.bitmap
             && this.cueLine == cue.line

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library/gradle/publish.gradle
+++ b/library/gradle/publish.gradle
@@ -29,49 +29,51 @@ task androidSourcesJar(type: Jar) {
  * Bintray Deploy
  * `$ ./gradlew clean library:assembleRelease androidJavaDocJar androidSourcesJar generatePomFileForJcenterPublication bintrayUpload`
  */
-publishing {
-    publications {
-        jcenter(MavenPublication) {
-            groupId project.getLibraryInfo().groupId
-            artifactId project.getLibraryInfo().artifactId
-            version project.getLibraryInfo().versionName
+project.afterEvaluate {
+    publishing {
+        publications {
+            jcenter(MavenPublication) {
+                groupId project.getLibraryInfo().groupId
+                artifactId project.getLibraryInfo().artifactId
+                version project.getLibraryInfo().versionName
 
-            artifact bundleReleaseAar
-            artifact androidJavaDocJar
-            artifact androidSourcesJar
+                artifact bundleReleaseAar
+                artifact androidJavaDocJar
+                artifact androidSourcesJar
 
-            // The generated POM doesn't include dependencies when building Android artifacts, so we manually
-            // add the dependencies to the POM here
-            pom.withXml {
-                def rootNode = asNode().appendNode('dependencies')
+                // The generated POM doesn't include dependencies when building Android artifacts, so we manually
+                // add the dependencies to the POM here
+                pom.withXml {
+                    def rootNode = asNode().appendNode('dependencies')
 
-                /**
-                 * Helper method to add dependencies to the POM node
-                 */
-                ext.addDependency = { Node dependenciesNode, Dependency dependency, String dependencyScope->
-                    // We don't add incomplete dependencies
-                    if (dependency.name == null ||
-                            dependency.name == 'unspecified' ||
-                            dependency.group == null ||
-                            dependency.version == null) {
-                        return
+                    /**
+                     * Helper method to add dependencies to the POM node
+                     */
+                    ext.addDependency = { Node dependenciesNode, Dependency dependency, String dependencyScope ->
+                        // We don't add incomplete dependencies
+                        if (dependency.name == null ||
+                                dependency.name == 'unspecified' ||
+                                dependency.group == null ||
+                                dependency.version == null) {
+                            return
+                        }
+
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', dependency.group)
+                        dependencyNode.appendNode('artifactId', dependency.name)
+                        dependencyNode.appendNode('version', dependency.version)
+                        dependencyNode.appendNode('scope', dependencyScope)
                     }
 
-                    def dependencyNode = dependenciesNode.appendNode('dependency')
-                    dependencyNode.appendNode('groupId', dependency.group)
-                    dependencyNode.appendNode('artifactId', dependency.name)
-                    dependencyNode.appendNode('version', dependency.version)
-                    dependencyNode.appendNode('scope', dependencyScope)
-                }
+                    // Iterate over the implementation dependencies, adding a <dependency> node for each
+                    configurations.implementation.dependencies.each {
+                        addDependency(rootNode, it, "runtime")
+                    }
 
-                // Iterate over the implementation dependencies, adding a <dependency> node for each
-                configurations.implementation.dependencies.each {
-                    addDependency(rootNode, it, "runtime")
-                }
-
-                // Iterate over the api dependencies, adding a <dependency> node for each
-                configurations.api.dependencies.each {
-                    addDependency(rootNode, it, "compile")
+                    // Iterate over the api dependencies, adding a <dependency> node for each
+                    configurations.api.dependencies.each {
+                        addDependency(rootNode, it, "compile")
+                    }
                 }
             }
         }

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/exoplayer/ExoMediaPlayer.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/exoplayer/ExoMediaPlayer.java
@@ -169,9 +169,14 @@ public class ExoMediaPlayer extends Player.DefaultEventListener {
         trackSelector = new DefaultTrackSelector(adaptiveTrackSelectionFactory);
 
         LoadControl loadControl = ExoMedia.Data.loadControl != null ? ExoMedia.Data.loadControl : new DefaultLoadControl();
-        player = ExoPlayerFactory.newInstance(renderers.toArray(new Renderer[renderers.size()]), trackSelector, loadControl);
+        player = new ExoPlayer.Builder(context, renderers.toArray(new Renderer[renderers.size()]))
+                .setTrackSelector(trackSelector)
+                .setLoadControl(loadControl)
+                .setBandwidthMeter(bandwidthMeter)
+                .build();
         player.addListener(this);
-        analyticsCollector = new AnalyticsCollector.Factory().createAnalyticsCollector(player, Clock.DEFAULT);
+        analyticsCollector = new AnalyticsCollector(Clock.DEFAULT);
+        analyticsCollector.setPlayer(player);
         player.addListener(analyticsCollector);
         setupDamSessionManagerAnalytics(drmSessionManager);
     }

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/renderer/RendererProvider.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/renderer/RendererProvider.java
@@ -126,7 +126,7 @@ public class RendererProvider {
     protected List<Renderer> buildVideoRenderers() {
         List<Renderer> renderers = new ArrayList<>();
 
-        renderers.add(new MediaCodecVideoRenderer(context, MediaCodecSelector.DEFAULT, videoJoiningTimeMs, drmSessionManager, false, handler, videoRendererEventListener, droppedFrameNotificationAmount));
+        renderers.add(new MediaCodecVideoRenderer(context, MediaCodecSelector.DEFAULT, videoJoiningTimeMs, false, handler, videoRendererEventListener, droppedFrameNotificationAmount));
 
         // Adds any registered classes
         List<String> classNames = ExoMedia.Data.registeredRendererClasses.get(ExoMedia.RendererType.VIDEO);

--- a/library/src/main/java/com/devbrackets/android/exomedia/core/source/builder/DefaultMediaSourceBuilder.java
+++ b/library/src/main/java/com/devbrackets/android/exomedia/core/source/builder/DefaultMediaSourceBuilder.java
@@ -25,6 +25,7 @@ import android.support.annotation.Nullable;
 import com.google.android.exoplayer2.extractor.DefaultExtractorsFactory;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
 import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.TransferListener;
 
@@ -34,8 +35,7 @@ public class DefaultMediaSourceBuilder extends MediaSourceBuilder {
     public MediaSource build(@NonNull Context context, @NonNull Uri uri, @NonNull String userAgent, @NonNull Handler handler, @Nullable TransferListener transferListener) {
         DataSource.Factory dataSourceFactory = buildDataSourceFactory(context, userAgent, transferListener);
 
-        return new ExtractorMediaSource.Factory(dataSourceFactory)
-                .setExtractorsFactory(new DefaultExtractorsFactory())
+        return new ProgressiveMediaSource.Factory(dataSourceFactory, new DefaultExtractorsFactory())
                 .createMediaSource(uri);
     }
 }


### PR DESCRIPTION
To support 2.10.0 or above, replaced some deprecated methods to new APIs.
I have build the demo with these new settings without any issues, so it should be safe to merge.

###### Addresses issue #.
- [x] This pull request follows the coding standards

###### This PR changes:
- ExoPlayer 2.9.6 -> 2.11.1
- Gradle:4.10.2 -> 5.6.4
- Gradle plugin:3.3.2 -> 3.5.3