### PR TITLE
[#735] Fixed Uri DataSource creation

### DIFF
--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/nmp/ExoMediaPlayerImpl.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/nmp/ExoMediaPlayerImpl.kt
@@ -27,7 +27,7 @@ import kotlin.concurrent.fixedRateTimer
 import kotlin.math.min
 
 class ExoMediaPlayerImpl(
-    private val config: PlayerConfig
+  private val config: PlayerConfig
 ) : Player.Listener, ExoMediaPlayer {
   companion object {
     private const val TAG = "ExoMediaPlayer"
@@ -65,10 +65,10 @@ class ExoMediaPlayerImpl(
   }
 
   override var surface: Surface? = null
-  set(value) {
-    field = value
-    exoPlayer.setVideoSurface(value)
-  }
+    set(value) {
+      field = value
+      exoPlayer.setVideoSurface(value)
+    }
 
   private var mediaSource: MediaSource? = null
 
@@ -124,10 +124,10 @@ class ExoMediaPlayerImpl(
       val currentWindow = timeline.getWindow(currentWindowIndex, Timeline.Window())
 
       return WindowInfo(
-          exoPlayer.previousWindowIndex,
-          currentWindowIndex,
-          exoPlayer.nextWindowIndex,
-          currentWindow
+        exoPlayer.previousWindowIndex,
+        currentWindowIndex,
+        exoPlayer.nextWindowIndex,
+        currentWindow
       )
     }
 
@@ -158,12 +158,13 @@ class ExoMediaPlayerImpl(
   override fun setMediaUri(uri: Uri?) {
     val mediaSource = uri?.let {
       val attributes = MediaSourceBuilder.MediaSourceAttributes(
-          config.context,
-          it,
-          config.handler,
-          config.userAgentProvider.userAgent,
-          config.bandwidthMeter.transferListener,
-          drmSessionManagerProvider ?: DefaultDrmSessionManagerProvider()
+        context = config.context,
+        uri = it,
+        handler = config.handler,
+        userAgent = config.userAgentProvider.userAgent,
+        transferListener = config.bandwidthMeter.transferListener,
+        drmSessionManagerProvider = drmSessionManagerProvider ?: DefaultDrmSessionManagerProvider(),
+        dataSourceFactoryProvider = config.dataSourceFactoryProvider
       )
 
       config.mediaSourceProvider.generate(attributes)
@@ -225,9 +226,9 @@ class ExoMediaPlayerImpl(
     val contentType = Util.getAudioContentTypeForStreamType(streamType)
 
     val audioAttributes = AudioAttributes.Builder()
-        .setUsage(usage)
-        .setContentType(contentType)
-        .build()
+      .setUsage(usage)
+      .setContentType(contentType)
+      .build()
 
     exoPlayer.setAudioAttributes(audioAttributes, false)
   }

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/nmp/config/PlayerConfig.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/nmp/config/PlayerConfig.kt
@@ -11,7 +11,7 @@ import com.devbrackets.android.exomedia.util.FallbackManager
 import androidx.media3.exoplayer.LoadControl
 import androidx.media3.exoplayer.RenderersFactory
 import androidx.media3.exoplayer.analytics.AnalyticsCollector
-import androidx.media3.exoplayer.source.MediaSourceFactory
+import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.upstream.BandwidthMeter
 
 /**
@@ -31,6 +31,6 @@ data class PlayerConfig(
   val loadControl: LoadControl,
   val userAgentProvider: UserAgentProvider,
   val mediaSourceProvider: MediaSourceProvider,
-  val mediaSourceFactory: MediaSourceFactory,
+  val mediaSourceFactory: MediaSource.Factory,
   val dataSourceFactoryProvider: DataSourceFactoryProvider
 )


### PR DESCRIPTION
Closes #735 
- [x] This pull request follows the coding standards

###### This PR changes:
 - Playing an item via a Uri now correctly uses the specified `dataSourceFactoryProvider`