### PR TITLE
Fallback Media Player standardization

### DIFF
--- a/demo/src/main/kotlin/com/devbrackets/android/exomediademo/playlist/AudioApi.kt
+++ b/demo/src/main/kotlin/com/devbrackets/android/exomediademo/playlist/AudioApi.kt
@@ -1,86 +1,93 @@
 package com.devbrackets.android.exomediademo.playlist
 
 import android.content.Context
-import android.media.AudioManager
 import android.net.Uri
 import android.os.PowerManager
 import androidx.annotation.FloatRange
 import androidx.annotation.IntRange
-
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
+import androidx.media3.exoplayer.util.EventLogger
 import com.devbrackets.android.exomedia.AudioPlayer
 import com.devbrackets.android.exomediademo.data.MediaItem
 import com.devbrackets.android.playlistcore.manager.BasePlaylistManager
-import androidx.media3.exoplayer.util.EventLogger
 
 class AudioApi(context: Context) : BaseMediaApi() {
-    private val audioPlayer: AudioPlayer = AudioPlayer(context.applicationContext)
+  private val audioPlayer: AudioPlayer = AudioPlayer(context.applicationContext)
 
-    override val isPlaying: Boolean
-        get() = audioPlayer.isPlaying
+  override val isPlaying: Boolean
+    get() = audioPlayer.isPlaying
 
-    override val handlesOwnAudioFocus: Boolean
-        get() = false
+  override val handlesOwnAudioFocus: Boolean
+    get() = false
 
-    override val currentPosition: Long
-        get() = if (prepared) audioPlayer.currentPosition else 0
+  override val currentPosition: Long
+    get() = audioPlayer.currentPosition
 
-    override val duration: Long
-        get() = if (prepared) audioPlayer.duration else 0
+  override val duration: Long
+    get() = audioPlayer.duration
 
-    override val bufferedPercent: Int
-        get() = bufferPercent
+  override val bufferedPercent: Int
+    get() = bufferPercent
 
-    init {
-        audioPlayer.setOnErrorListener(this)
-        audioPlayer.setOnPreparedListener(this)
-        audioPlayer.setOnCompletionListener(this)
-        audioPlayer.setOnSeekCompletionListener(this)
-        audioPlayer.setOnBufferUpdateListener(this)
+  init {
+    audioPlayer.setOnErrorListener(this)
+    audioPlayer.setOnPreparedListener(this)
+    audioPlayer.setOnCompletionListener(this)
+    audioPlayer.setOnSeekCompletionListener(this)
+    audioPlayer.setOnBufferUpdateListener(this)
 
-        audioPlayer.setWakeLevel(PowerManager.PARTIAL_WAKE_LOCK)
-        audioPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC)
-        audioPlayer.setAnalyticsListener(EventLogger(null))
+    audioPlayer.setWakeLevel(PowerManager.PARTIAL_WAKE_LOCK)
+    audioPlayer.setAudioAttributes(getAudioAttributes(C.USAGE_MEDIA, C.AUDIO_CONTENT_TYPE_MUSIC))
+    audioPlayer.setAnalyticsListener(EventLogger(null))
+  }
+
+  override fun play() {
+    audioPlayer.start()
+  }
+
+  override fun pause() {
+    audioPlayer.pause()
+  }
+
+  override fun stop() {
+    audioPlayer.stop()
+  }
+
+  override fun reset() {
+    audioPlayer.reset()
+  }
+
+  override fun release() {
+    audioPlayer.release()
+  }
+
+  override fun setVolume(@FloatRange(from = 0.0, to = 1.0) left: Float, @FloatRange(from = 0.0, to = 1.0) right: Float) {
+    audioPlayer.volume = (left + right) / 2
+  }
+
+  override fun seekTo(@IntRange(from = 0L) milliseconds: Long) {
+    audioPlayer.seekTo(milliseconds.toInt().toLong())
+  }
+
+  override fun handlesItem(item: MediaItem): Boolean {
+    return item.mediaType == BasePlaylistManager.AUDIO
+  }
+
+  override fun playItem(item: MediaItem) {
+    try {
+      bufferPercent = 0
+      audioPlayer.setMedia(Uri.parse(if (item.downloaded) item.downloadedMediaUri else item.mediaUrl))
+    } catch (e: Exception) {
+      //Purposefully left blank
     }
+  }
 
-    override fun play() {
-        audioPlayer.start()
-    }
-
-    override fun pause() {
-        audioPlayer.pause()
-    }
-
-    override fun stop() {
-        audioPlayer.stop()
-    }
-
-    override fun reset() {
-        audioPlayer.reset()
-    }
-
-    override fun release() {
-        audioPlayer.release()
-    }
-
-    override fun setVolume(@FloatRange(from = 0.0, to = 1.0) left: Float, @FloatRange(from = 0.0, to = 1.0) right: Float) {
-        audioPlayer.volume = (left + right) / 2
-    }
-
-    override fun seekTo(@IntRange(from = 0L) milliseconds: Long) {
-        audioPlayer.seekTo(milliseconds.toInt().toLong())
-    }
-
-    override fun handlesItem(item: MediaItem): Boolean {
-        return item.mediaType == BasePlaylistManager.AUDIO
-    }
-
-    override fun playItem(item: MediaItem) {
-        try {
-            prepared = false
-            bufferPercent = 0
-            audioPlayer.setMedia(Uri.parse(if (item.downloaded) item.downloadedMediaUri else item.mediaUrl))
-        } catch (e: Exception) {
-            //Purposefully left blank
-        }
-    }
+  @Suppress("SameParameterValue")
+  private fun getAudioAttributes(@C.AudioUsage usage: Int, @C.AudioContentType contentType: Int): AudioAttributes {
+    return AudioAttributes.Builder()
+      .setUsage(usage)
+      .setContentType(contentType)
+      .build()
+  }
 }

--- a/demo/src/main/kotlin/com/devbrackets/android/exomediademo/playlist/BaseMediaApi.kt
+++ b/demo/src/main/kotlin/com/devbrackets/android/exomediademo/playlist/BaseMediaApi.kt
@@ -6,34 +6,32 @@ import com.devbrackets.android.playlistcore.api.MediaPlayerApi
 import com.devbrackets.android.playlistcore.listener.MediaStatusListener
 
 abstract class BaseMediaApi : MediaPlayerApi<MediaItem>, OnPreparedListener, OnCompletionListener, OnErrorListener, OnSeekCompletionListener, OnBufferUpdateListener {
-    protected var prepared: Boolean = false
-    protected var bufferPercent: Int = 0
+  protected var bufferPercent: Int = 0
 
-    protected var statusListener: MediaStatusListener<MediaItem>? = null
+  protected var statusListener: MediaStatusListener<MediaItem>? = null
 
-    override fun setMediaStatusListener(listener: MediaStatusListener<MediaItem>) {
-        statusListener = listener
-    }
+  override fun setMediaStatusListener(listener: MediaStatusListener<MediaItem>) {
+    statusListener = listener
+  }
 
-    override fun onCompletion() {
-        statusListener?.onCompletion(this)
-    }
+  override fun onCompletion() {
+    statusListener?.onCompletion(this)
+  }
 
-    override fun onError(e: Exception?): Boolean {
-        return statusListener?.onError(this) == true
-    }
+  override fun onError(e: Exception?): Boolean {
+    return statusListener?.onError(this) == true
+  }
 
-    override fun onPrepared() {
-        prepared = true
-        statusListener?.onPrepared(this)
-    }
+  override fun onPrepared() {
+    statusListener?.onPrepared(this)
+  }
 
-    override fun onSeekComplete() {
-        statusListener?.onSeekComplete(this)
-    }
+  override fun onSeekComplete() {
+    statusListener?.onSeekComplete(this)
+  }
 
-    override fun onBufferingUpdate(percent: Int) {
-        bufferPercent = percent
-        statusListener?.onBufferingUpdate(this, percent)
-    }
+  override fun onBufferingUpdate(percent: Int) {
+    bufferPercent = percent
+    statusListener?.onBufferingUpdate(this, percent)
+  }
 }

--- a/demo/src/main/kotlin/com/devbrackets/android/exomediademo/playlist/VideoApi.kt
+++ b/demo/src/main/kotlin/com/devbrackets/android/exomediademo/playlist/VideoApi.kt
@@ -3,95 +3,95 @@ package com.devbrackets.android.exomediademo.playlist
 import android.net.Uri
 import androidx.annotation.FloatRange
 import androidx.annotation.IntRange
-import com.devbrackets.android.exomedia.ui.widget.controls.DefaultVideoControls
+import com.devbrackets.android.exomedia.listener.OnPreparedListener
 import com.devbrackets.android.exomedia.ui.widget.VideoView
+import com.devbrackets.android.exomedia.ui.widget.controls.DefaultVideoControls
 import com.devbrackets.android.exomediademo.data.MediaItem
 import com.devbrackets.android.playlistcore.data.PlaybackState
 import com.devbrackets.android.playlistcore.listener.PlaylistListener
 import com.devbrackets.android.playlistcore.manager.BasePlaylistManager
 
-class VideoApi(var videoView: VideoView) : BaseMediaApi(), PlaylistListener<MediaItem> {
+class VideoApi(var videoView: VideoView) : BaseMediaApi(), PlaylistListener<MediaItem>, OnPreparedListener {
 
-    override val isPlaying: Boolean
-        get() = videoView.isPlaying
+  override val isPlaying: Boolean
+    get() = videoView.isPlaying
 
-    override val handlesOwnAudioFocus: Boolean
-        get() = false
+  override val handlesOwnAudioFocus: Boolean
+    get() = false
 
-    override val currentPosition: Long
-        get() = if (prepared) videoView.currentPosition else 0
+  override val currentPosition: Long
+    get() = videoView.currentPosition
 
-    override val duration: Long
-        get() = if (prepared) videoView.duration else 0
+  override val duration: Long
+    get() = videoView.duration
 
-    override val bufferedPercent: Int
-        get() = bufferPercent
+  override val bufferedPercent: Int
+    get() = bufferPercent
 
-    init {
-        videoView.setOnErrorListener(this)
-        videoView.setOnPreparedListener(this)
-        videoView.setOnCompletionListener(this)
-        videoView.setOnSeekCompletionListener(this)
-        videoView.setOnBufferUpdateListener(this)
+  init {
+    videoView.setOnErrorListener(this)
+    videoView.setOnPreparedListener(this)
+    videoView.setOnCompletionListener(this)
+    videoView.setOnSeekCompletionListener(this)
+    videoView.setOnBufferUpdateListener(this)
+  }
+
+  override fun play() {
+    videoView.start()
+  }
+
+  override fun pause() {
+    videoView.pause()
+  }
+
+  override fun stop() {
+    videoView.stopPlayback()
+  }
+
+  override fun reset() {
+    // Purposefully left blank
+  }
+
+  override fun release() {
+    videoView.suspend()
+  }
+
+  override fun setVolume(@FloatRange(from = 0.0, to = 1.0) left: Float, @FloatRange(from = 0.0, to = 1.0) right: Float) {
+    videoView.volume = (left + right) / 2
+  }
+
+  override fun seekTo(@IntRange(from = 0L) milliseconds: Long) {
+    videoView.seekTo(milliseconds.toInt().toLong())
+  }
+
+  override fun handlesItem(item: MediaItem): Boolean {
+    return item.mediaType == BasePlaylistManager.VIDEO
+  }
+
+  override fun playItem(item: MediaItem) {
+    bufferPercent = 0
+    videoView.setVideoURI(Uri.parse(if (item.downloaded) item.downloadedMediaUri else item.mediaUrl))
+  }
+
+  /*
+   * PlaylistListener methods used for keeping the VideoControls provided
+   * by the ExoMedia VideoView up-to-date with the current playback state
+   */
+  override fun onPlaylistItemChanged(currentItem: MediaItem?, hasNext: Boolean, hasPrevious: Boolean): Boolean {
+    (videoView.videoControls as? DefaultVideoControls)?.let { controls ->
+      // Updates the VideoControls display text
+      controls.setTitle(currentItem?.title ?: "")
+      controls.setSubTitle(currentItem?.album ?: "")
+
+      // Updates the VideoControls button visibilities
+      controls.setPreviousButtonEnabled(hasPrevious)
+      controls.setNextButtonEnabled(hasNext)
     }
 
-    override fun play() {
-        videoView.start()
-    }
+    return false
+  }
 
-    override fun pause() {
-        videoView.pause()
-    }
-
-    override fun stop() {
-        videoView.stopPlayback()
-    }
-
-    override fun reset() {
-        // Purposefully left blank
-    }
-
-    override fun release() {
-        videoView.suspend()
-    }
-
-    override fun setVolume(@FloatRange(from = 0.0, to = 1.0) left: Float, @FloatRange(from = 0.0, to = 1.0) right: Float) {
-        videoView.volume = (left + right) / 2
-    }
-
-    override fun seekTo(@IntRange(from = 0L) milliseconds: Long) {
-        videoView.seekTo(milliseconds.toInt().toLong())
-    }
-
-    override fun handlesItem(item: MediaItem): Boolean {
-        return item.mediaType == BasePlaylistManager.VIDEO
-    }
-
-    override fun playItem(item: MediaItem) {
-        prepared = false
-        bufferPercent = 0
-        videoView.setVideoURI(Uri.parse(if (item.downloaded) item.downloadedMediaUri else item.mediaUrl))
-    }
-
-    /*
-     * PlaylistListener methods used for keeping the VideoControls provided
-     * by the ExoMedia VideoView up-to-date with the current playback state
-     */
-    override fun onPlaylistItemChanged(currentItem: MediaItem?, hasNext: Boolean, hasPrevious: Boolean): Boolean {
-        (videoView.videoControls as? DefaultVideoControls)?.let { controls ->
-            // Updates the VideoControls display text
-            controls.setTitle(currentItem?.title ?: "")
-            controls.setSubTitle(currentItem?.album ?: "")
-
-            // Updates the VideoControls button visibilities
-            controls.setPreviousButtonEnabled(hasPrevious)
-            controls.setNextButtonEnabled(hasNext)
-        }
-
-        return false
-    }
-
-    override fun onPlaybackStateChanged(playbackState: PlaybackState): Boolean {
-        return false
-    }
+  override fun onPlaybackStateChanged(playbackState: PlaybackState): Boolean {
+    return false
+  }
 }

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/AudioPlayer.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/AudioPlayer.kt
@@ -177,9 +177,5 @@ open class AudioPlayer(protected val audioPlayerImpl: AudioPlayerApi) : AudioPla
     override fun onMediaPlaybackEnded() {
       onPlaybackEnded()
     }
-
-    override fun onPrepared() {
-      audioPlayerImpl.onMediaPrepared()
-    }
   }
 }

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/core/audio/AudioPlayerApi.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/core/audio/AudioPlayerApi.kt
@@ -1,16 +1,16 @@
 package com.devbrackets.android.exomedia.core.audio
 
-import android.media.AudioManager
 import android.net.Uri
 import androidx.annotation.FloatRange
 import androidx.annotation.IntRange
+import androidx.media3.common.AudioAttributes
 import androidx.media3.common.Player
-import com.devbrackets.android.exomedia.core.ListenerMux
-import com.devbrackets.android.exomedia.core.renderer.RendererType
-import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.TrackGroupArray
+import com.devbrackets.android.exomedia.core.ListenerMux
+import com.devbrackets.android.exomedia.core.renderer.RendererType
+import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
 
 /**
  * The basic APIs expected in the backing media player
@@ -144,15 +144,13 @@ interface AudioPlayerApi {
   fun setPlaybackSpeed(speed: Float): Boolean
 
   /**
-   * Sets the audio stream type for this MediaPlayer. See [AudioManager]
-   * for a list of stream types. Must call this method before prepare() or
-   * prepareAsync() in order for the target stream type to become effective
-   * thereafter.
+   * Sets the audio attributes for this [AudioPlayerApi].
+   * You must call this method before loading media with [setMedia] in order
+   * for the audio attributes to become effective.
    *
-   * @param streamType The audio stream type
-   * @see android.media.AudioManager
+   * @param attributes The [AudioAttributes] to apply
    */
-  fun setAudioStreamType(streamType: Int)
+  fun setAudioAttributes(attributes: AudioAttributes)
 
   /**
    * Determines if the current video player implementation supports
@@ -225,9 +223,6 @@ interface AudioPlayerApi {
   fun setWakeLevel(levelAndFlags: Int)
 
   fun setListenerMux(listenerMux: ListenerMux)
-
-  //TODO: remove onMediaPrepared and let the implementations handle that internally?
-  fun onMediaPrepared()
 
   /**
    * Sets the repeat mode for this MediaPlayer.

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/core/audio/ExoAudioPlayer.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/core/audio/ExoAudioPlayer.kt
@@ -2,18 +2,19 @@ package com.devbrackets.android.exomedia.core.audio
 
 import android.net.Uri
 import androidx.annotation.IntRange
+import androidx.media3.common.AudioAttributes
 import androidx.media3.common.Metadata
 import androidx.media3.common.Player
-import com.devbrackets.android.exomedia.core.ListenerMux
-import com.devbrackets.android.exomedia.nmp.ExoMediaPlayerImpl
-import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
-import com.devbrackets.android.exomedia.core.listener.MetadataListener
-import com.devbrackets.android.exomedia.core.renderer.RendererType
-import com.devbrackets.android.exomedia.listener.OnBufferUpdateListener
-import com.devbrackets.android.exomedia.nmp.config.PlayerConfig
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.TrackGroupArray
+import com.devbrackets.android.exomedia.core.ListenerMux
+import com.devbrackets.android.exomedia.core.listener.MetadataListener
+import com.devbrackets.android.exomedia.core.renderer.RendererType
+import com.devbrackets.android.exomedia.listener.OnBufferUpdateListener
+import com.devbrackets.android.exomedia.nmp.ExoMediaPlayerImpl
+import com.devbrackets.android.exomedia.nmp.config.PlayerConfig
+import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
 
 /**
  * A [AudioPlayerApi] implementation that uses the ExoPlayer
@@ -142,8 +143,8 @@ open class ExoAudioPlayer(protected val config: PlayerConfig) : AudioPlayerApi {
     return true
   }
 
-  override fun setAudioStreamType(streamType: Int) {
-    corePlayer.setAudioStreamType(streamType)
+  override fun setAudioAttributes(attributes: AudioAttributes) {
+    corePlayer.setAudioAttributes(attributes)
   }
 
   override fun setWakeLevel(levelAndFlags: Int) {
@@ -183,10 +184,6 @@ open class ExoAudioPlayer(protected val config: PlayerConfig) : AudioPlayerApi {
     this._listenerMux = listenerMux
     corePlayer.addListener(listenerMux)
     corePlayer.addAnalyticsListener(listenerMux)
-  }
-
-  override fun onMediaPrepared() {
-    //Purposefully left blank
   }
 
   override fun setRepeatMode(@Player.RepeatMode repeatMode: Int) {

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/core/video/ExoVideoPlayer.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/core/video/ExoVideoPlayer.kt
@@ -1,24 +1,24 @@
 package com.devbrackets.android.exomedia.core.video
 
 import android.net.Uri
-import android.util.Log
-import android.view.*
+import android.view.Surface
 import androidx.annotation.IntRange
+import androidx.media3.common.AudioAttributes
 import androidx.media3.common.Metadata
 import androidx.media3.common.VideoSize
+import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.TrackGroupArray
 import com.devbrackets.android.exomedia.core.ListenerMux
 import com.devbrackets.android.exomedia.core.listener.CaptionListener
 import com.devbrackets.android.exomedia.core.listener.MetadataListener
 import com.devbrackets.android.exomedia.core.listener.VideoSizeListener
 import com.devbrackets.android.exomedia.core.renderer.RendererType
+import com.devbrackets.android.exomedia.core.video.surface.SurfaceEnvelope
 import com.devbrackets.android.exomedia.listener.OnBufferUpdateListener
 import com.devbrackets.android.exomedia.nmp.ExoMediaPlayerImpl
 import com.devbrackets.android.exomedia.nmp.config.PlayerConfig
 import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
-import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
-import androidx.media3.exoplayer.source.MediaSource
-import androidx.media3.exoplayer.source.TrackGroupArray
-import com.devbrackets.android.exomedia.core.video.surface.SurfaceEnvelope
 
 class ExoVideoPlayer(
   private val playerConfig: PlayerConfig,
@@ -202,8 +202,8 @@ class ExoVideoPlayer(
     return true
   }
 
-  override fun setAudioStreamType(streamType: Int) {
-    corePlayer.setAudioStreamType(streamType)
+  override fun setAudioAttributes(attributes: AudioAttributes) {
+    corePlayer.setAudioAttributes(attributes)
   }
 
   override fun setRepeatMode(repeatMode: Int) {
@@ -230,10 +230,6 @@ class ExoVideoPlayer(
     this._listenerMux = listenerMux
     corePlayer.addListener(listenerMux)
     corePlayer.addAnalyticsListener(listenerMux)
-  }
-
-  override fun onMediaPrepared() {
-    // Purposefully left blank
   }
 
   protected inner class InternalListeners : MetadataListener, OnBufferUpdateListener, VideoSizeListener {

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/fallback/FallbackMediaPlayer.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/fallback/FallbackMediaPlayer.kt
@@ -1,0 +1,162 @@
+package com.devbrackets.android.exomedia.fallback
+
+import android.net.Uri
+import android.os.PowerManager
+import android.view.Surface
+import androidx.annotation.IntRange
+import androidx.media3.common.AudioAttributes
+
+interface FallbackMediaPlayer {
+
+  /**
+   * Represents the session ID for the audio tracks.
+   */
+  val audioSessionId: Int
+
+  /**
+   * The current volume for the Audio tracks. This will be between `0.0` and `1.0`
+   * inclusive
+   */
+  var volume: Float
+
+  /**
+   * Returns `true` if any media is currently playing
+   */
+  val playing: Boolean
+
+  /**
+   * Determines if media specified by [setMedia] should
+   * start playing when the content is ready (buffered)
+   */
+  var playWhenReady: Boolean
+
+  /**
+   * Returns the duration of the loaded media in milliseconds, if no media is loaded then
+   * `0` will be returned.
+   */
+  val duration: Long
+
+  /**
+   * Returns the playback position in milliseconds
+   */
+  val currentPosition: Long
+
+  /**
+   * Returns an estimated percentage of the loaded media that has been buffered,
+   * this will be a value between `0` and `100`. If no media is loaded then `0` will
+   * be returned
+   */
+  val bufferedPercent: Int
+
+  /**
+   * The speed of playback for the media; must be greater than `0` and between
+   * `0` and `1`
+   */
+  var playbackSpeed: Float
+
+  /**
+   * The correction to apply for the pitch. It's recommended to set the pitch correction
+   * to the same amount as the `playbackSpeed`
+   */
+  var playbackPitch: Float
+
+  /**
+   * The current media playback state
+   */
+  val playbackState: State
+
+  /**
+   * The surface to play video media on
+   */
+  var surface: Surface?
+
+  /**
+   * Defines the [Uri] for media to play
+   */
+  fun setMedia(uri: Uri?)
+
+  /**
+   * Seeks the media playback to the specified position in milliseconds
+   */
+  fun seekTo(@IntRange(from = 0) positionMs: Long)
+
+  /**
+   * Starts or resumes playback of the media specified by [setMedia]
+   */
+  fun start()
+
+  /**
+   * Stops the media playback in a way that it can quickly be resumed (see [start])
+   */
+  fun pause()
+
+  /**
+   * Stops the media playback, clears any cached data, and disconnects from
+   * the media specified by [setMedia]
+   */
+  fun stop()
+
+  /**
+   * Moves the playback position of the media specified by [setMedia]
+   * to the start (`0`).
+   *
+   * @return `true` if the media was successfully restarted
+   */
+  fun restart(): Boolean
+
+  /**
+   * Stops the current media playback and resets the listener states
+   * so that we receive the callbacks for events like onPrepared
+   */
+  fun reset()
+
+  /**
+   * Releases any resources being held by this player. In order to play media after
+   * a `release` a new player will need to be instantiated
+   */
+  fun release()
+
+  fun setAudioAttributes(attributes: AudioAttributes)
+
+  /**
+   * This function has the MediaPlayer access the low-level power manager
+   * service to control the device's power usage while playing is occurring.
+   * The parameter is a combination of [android.os.PowerManager] wake flags.
+   *
+   * Use of this method requires [android.Manifest.permission.WAKE_LOCK]
+   * permission.
+   *
+   * By default, no attempt is made to keep the device awake during playback.
+   *
+   * @param levelAndFlags The wake lock level and any flags to apply, see [PowerManager.newWakeLock]
+   */
+  fun setWakeLevel(levelAndFlags: Int)
+
+  fun setListener(listener: Listener?)
+
+  enum class State {
+    IDLE,
+    PREPARING,
+    BUFFERING,
+    SEEKING,
+    READY,
+    PLAYING,
+    PAUSED,
+    COMPLETED,
+    STOPPED,
+    RELEASED,
+    ERROR
+  }
+
+  interface Listener {
+    fun onStateChange(state: State)
+
+    fun onBufferUpdate(mediaPlayer: FallbackMediaPlayer, percent: Int)
+
+    fun onSeekComplete(mediaPlayer: FallbackMediaPlayer)
+
+    fun onError(mediaPlayer: FallbackMediaPlayer, what: Int, extra: Int): Boolean
+
+    fun onVideoSizeChanged(mediaPlayer: FallbackMediaPlayer, width: Int, height: Int)
+  }
+}

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/fallback/FallbackMediaPlayerImpl.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/fallback/FallbackMediaPlayerImpl.kt
@@ -1,0 +1,325 @@
+package com.devbrackets.android.exomedia.fallback
+
+import android.content.Context
+import android.media.MediaPlayer
+import android.media.PlaybackParams
+import android.net.Uri
+import android.os.Build
+import android.util.Log
+import android.view.Surface
+import androidx.annotation.FloatRange
+import androidx.annotation.IntRange
+import androidx.media3.common.AudioAttributes
+import com.devbrackets.android.exomedia.fallback.FallbackMediaPlayer.State
+import java.io.IOException
+
+class FallbackMediaPlayerImpl(
+  private val context: Context
+):
+  FallbackMediaPlayer,
+  MediaPlayer.OnBufferingUpdateListener,
+  MediaPlayer.OnErrorListener,
+  MediaPlayer.OnPreparedListener,
+  MediaPlayer.OnCompletionListener,
+  MediaPlayer.OnSeekCompleteListener,
+  MediaPlayer.OnInfoListener,
+  MediaPlayer.OnVideoSizeChangedListener
+{
+  companion object {
+    private const val TAG = "FallbackMediaPlayerImpl"
+
+    // States representing we have access to media information / control
+    private val accessibleStates = setOf(
+      State.BUFFERING,
+      State.SEEKING,
+      State.READY,
+      State.PLAYING,
+      State.PAUSED
+    )
+  }
+
+  override var playbackState = State.IDLE
+    private set
+
+  private val mediaPlayer: MediaPlayer by lazy {
+    MediaPlayer().apply {
+      setOnInfoListener(this@FallbackMediaPlayerImpl)
+      setOnErrorListener(this@FallbackMediaPlayerImpl)
+      setOnPreparedListener(this@FallbackMediaPlayerImpl)
+      setOnCompletionListener(this@FallbackMediaPlayerImpl)
+      setOnSeekCompleteListener(this@FallbackMediaPlayerImpl)
+      setOnBufferingUpdateListener(this@FallbackMediaPlayerImpl)
+      setOnVideoSizeChangedListener(this@FallbackMediaPlayerImpl)
+    }
+  }
+
+  override var playWhenReady = false
+
+  private var prepared: Boolean = false
+  private var requestedSeek: Long = 0
+  private var currentBufferPercent: Int = 0
+
+  @FloatRange(from = 0.0, to = 1.0)
+  private var requestedVolume = 1.0f
+
+  private var listener: FallbackMediaPlayer.Listener? = null
+
+  private var headers: Map<String, String>? = null
+
+  override var volume: Float
+    get() = requestedVolume
+    set(value) {
+      requestedVolume = value
+      mediaPlayer.setVolume(value, value)
+    }
+
+  override val duration: Long
+    get() = if (!prepared || !mediaAccessible) {
+      0
+    } else mediaPlayer.duration.toLong()
+
+  override val currentPosition: Long
+    get() = if (!prepared || !mediaAccessible) {
+      0
+    } else mediaPlayer.currentPosition.toLong()
+
+  override val playing: Boolean
+    get() = mediaAccessible && mediaPlayer.isPlaying
+
+  override val bufferedPercent: Int
+    get() = currentBufferPercent
+
+  override val audioSessionId: Int
+    get() = mediaPlayer.audioSessionId
+
+  override var playbackSpeed: Float
+    get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      mediaPlayer.playbackParams.speed
+    } else 1f
+    set(value) {
+      updatePlaybackParams(value, playbackPitch)
+    }
+
+  override var playbackPitch: Float
+    get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      mediaPlayer.playbackParams.pitch
+    } else 1f
+    set(value) {
+      updatePlaybackParams(playbackSpeed, value)
+    }
+
+  private val mediaAccessible: Boolean
+    get() = accessibleStates.contains(playbackState)
+
+  override var surface: Surface? = null
+    set(value) {
+      field = value
+      mediaPlayer.setSurface(surface)
+    }
+
+  override fun seekTo(@IntRange(from = 0) positionMs: Long) {
+    if (!mediaAccessible) {
+      requestedSeek = positionMs
+      return
+    }
+
+    reportPlaybackState(State.SEEKING)
+    mediaPlayer.seekTo(positionMs.toInt())
+    requestedSeek = 0
+  }
+
+  override fun start() {
+    if (mediaAccessible) {
+      mediaPlayer.start()
+      reportPlaybackState(State.PLAYING)
+    }
+
+    playWhenReady = true
+  }
+
+  override fun pause() {
+    if (mediaAccessible && mediaPlayer.isPlaying) {
+      mediaPlayer.pause()
+      reportPlaybackState(State.PAUSED)
+    }
+
+    playWhenReady = false
+  }
+
+  override fun stop() {
+    tryWhenAccessible {
+      mediaPlayer.stop()
+    }
+
+    prepared = false
+    playWhenReady = false
+    reportPlaybackState(State.STOPPED)
+  }
+
+  override fun restart(): Boolean {
+    if (!prepared || !(accessibleStates.contains(playbackState) || playbackState == State.COMPLETED)) {
+      return false
+    }
+
+    seekTo(0)
+    start()
+
+    return true
+  }
+
+  override fun reset() {
+    mediaPlayer.reset()
+
+    prepared = false
+    playWhenReady = false
+    reportPlaybackState(State.IDLE)
+  }
+
+  override fun release() {
+    tryWhenAccessible {
+      mediaPlayer.reset()
+      mediaPlayer.release()
+    }
+
+    prepared = false
+    playWhenReady = false
+    reportPlaybackState(State.RELEASED)
+  }
+
+  override fun setAudioAttributes(attributes: AudioAttributes) {
+    mediaPlayer.setAudioAttributes(attributes.audioAttributesV21.audioAttributes)
+  }
+
+  override fun setWakeLevel(levelAndFlags: Int) {
+    mediaPlayer.setWakeMode(context, levelAndFlags)
+  }
+
+  override fun setMedia(uri: Uri?) {
+    prepared = false
+    if (uri == null) {
+      return
+    }
+
+    currentBufferPercent = 0
+
+    try {
+      mediaPlayer.reset()
+      mediaPlayer.setDataSource(context.applicationContext, uri, headers)
+      mediaPlayer.prepareAsync()
+
+      reportPlaybackState(State.PREPARING)
+    } catch (ex: IOException) {
+      Log.w(TAG, "Unable to open content: $uri", ex)
+      reportPlaybackState(State.ERROR)
+
+      listener?.onError(this, MediaPlayer.MEDIA_ERROR_UNKNOWN, 0)
+    } catch (ex: IllegalArgumentException) {
+      Log.w(TAG, "Unable to open content: $uri", ex)
+      reportPlaybackState(State.ERROR)
+      listener?.onError(this, MediaPlayer.MEDIA_ERROR_UNKNOWN, 0)
+    }
+  }
+
+  override fun setListener(listener: FallbackMediaPlayer.Listener?) {
+    this.listener = listener
+  }
+
+  override fun onBufferingUpdate(mp: MediaPlayer, percent: Int) {
+    currentBufferPercent = percent
+    listener?.onBufferUpdate(this, percent)
+  }
+
+  override fun onCompletion(mp: MediaPlayer) {
+    reportPlaybackState(State.COMPLETED)
+  }
+
+  override fun onSeekComplete(mp: MediaPlayer) {
+    listener?.onSeekComplete(this)
+
+    if (playWhenReady) {
+      start()
+    } else if (prepared) {
+      reportPlaybackState(State.PAUSED)
+    }
+  }
+
+  override fun onError(mp: MediaPlayer?, what: Int, extra: Int): Boolean {
+    reportPlaybackState(State.ERROR)
+
+    return listener?.onError(this, what, extra) == true
+  }
+
+  override fun onPrepared(mp: MediaPlayer) {
+    prepared = true
+    reportPlaybackState(State.READY)
+    listener?.onVideoSizeChanged(this, mp.videoWidth, mp.videoHeight)
+
+    if (requestedSeek != 0L) {
+      seekTo(requestedSeek)
+    } else if (playWhenReady) {
+      start()
+    }
+  }
+
+  override fun onInfo(mp: MediaPlayer, what: Int, extra: Int): Boolean {
+    handleMediaInfo(what)
+    return false
+  }
+
+  override fun onVideoSizeChanged(mp: MediaPlayer, width: Int, height: Int) {
+    listener?.onVideoSizeChanged(this, mp.videoWidth, mp.videoHeight)
+  }
+
+  private fun reportPlaybackState(state: State) {
+    playbackState = state
+    listener?.onStateChange(state)
+  }
+
+  private fun updatePlaybackParams(speed: Float, pitch: Float) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      return
+    }
+
+    mediaPlayer.playbackParams = PlaybackParams().apply {
+      this.speed = speed
+      this.pitch = pitch
+    }
+  }
+
+  private fun tryWhenAccessible(action: () -> Unit) {
+    if (!mediaAccessible) {
+      return
+    }
+
+    try {
+      action()
+    } catch (e: Exception) {
+      Log.d(TAG, "error calling action()", e)
+    }
+  }
+
+  private fun handleMediaInfo(mediaInfo: Int) {
+    if (mediaInfo == MediaPlayer.MEDIA_INFO_BUFFERING_START) {
+      reportPlaybackState(State.BUFFERING)
+      return
+    }
+
+    if (mediaInfo != MediaPlayer.MEDIA_INFO_BUFFERING_END) {
+      return
+    }
+
+    // Double-Check if the media is actually playing (resumed on buffer completion)
+    if (playing) {
+      reportPlaybackState(State.PLAYING)
+      return
+    }
+
+    if (playWhenReady) {
+      start()
+      return
+    }
+
+    // We assume that the media was already playing when buffering ends
+    reportPlaybackState(State.PAUSED)
+  }
+}

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/fallback/video/NativeVideoPlayer.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/fallback/video/NativeVideoPlayer.kt
@@ -1,123 +1,53 @@
 package com.devbrackets.android.exomedia.fallback.video
 
-import android.content.ContentValues
 import android.content.Context
-import android.media.AudioAttributes
-import android.media.MediaPlayer
-import android.media.PlaybackParams
 import android.net.Uri
-import android.os.Build
-import android.util.Log
-import android.view.*
-import androidx.annotation.FloatRange
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
+import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.TrackGroupArray
 import com.devbrackets.android.exomedia.core.ListenerMux
 import com.devbrackets.android.exomedia.core.listener.CaptionListener
 import com.devbrackets.android.exomedia.core.renderer.RendererType
 import com.devbrackets.android.exomedia.core.video.VideoPlayerApi
-import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
-import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
-import androidx.media3.exoplayer.source.MediaSource
-import androidx.media3.exoplayer.source.TrackGroupArray
 import com.devbrackets.android.exomedia.core.video.surface.SurfaceEnvelope
-import java.io.IOException
+import com.devbrackets.android.exomedia.fallback.FallbackMediaPlayer
+import com.devbrackets.android.exomedia.fallback.FallbackMediaPlayerImpl
+import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
 
 class NativeVideoPlayer(
-  protected var context: Context,
+  private var context: Context,
   private val surface: SurfaceEnvelope
 ) : VideoPlayerApi {
 
-  protected var headers: Map<String, String>? = null
-
-  protected var currentState = State.IDLE
-
-  // TODO: this works differently from the NativeAudioPlayer, why?
-  protected val mediaPlayer: MediaPlayer by lazy {
-    MediaPlayer().apply {
-      setOnInfoListener(internalListeners)
-      setOnErrorListener(internalListeners)
-      setOnPreparedListener(internalListeners)
-      setOnCompletionListener(internalListeners)
-      setOnSeekCompleteListener(internalListeners)
-      setOnBufferingUpdateListener(internalListeners)
-      setOnVideoSizeChangedListener(internalListeners)
-
-      setAudioAttributes(AudioAttributes.Builder().setContentType(AudioAttributes.CONTENT_TYPE_MUSIC).build())
-      setScreenOnWhilePlaying(true)
+  private val mediaPlayer: FallbackMediaPlayer by lazy {
+    FallbackMediaPlayerImpl(context).apply {
+      setAudioAttributes(getAudioAttributes(C.USAGE_MEDIA, C.AUDIO_CONTENT_TYPE_MOVIE))
     }
   }
 
-  protected var playRequested = false
-  protected var requestedSeek: Long = 0
-  protected var currentBufferPercent: Int = 0
+  private var _listenerMux: ListenerMux? = null
 
-  @FloatRange(from = 0.0, to = 1.0)
-  protected var requestedVolume = 1.0f
-
-  protected var _listenerMux: ListenerMux? = null
-
-  var internalListeners = InternalListeners()
-  protected var surfaceCallback = SurfaceCallback()
-
-  /**
-   * Register a callback to be invoked when the end of a media file
-   * has been reached during playback.
-   */
-  var onCompletionListener: MediaPlayer.OnCompletionListener? = null
-
-  /**
-   * Register a callback to be invoked when the media file
-   * is loaded and ready to go.
-   */
-  var onPreparedListener: MediaPlayer.OnPreparedListener? = null
-
-  /**
-   * Register a callback to be invoked when the status of a network
-   * stream's buffer has changed.
-   */
-  var onBufferingUpdateListener: MediaPlayer.OnBufferingUpdateListener? = null
-
-  /**
-   * Register a callback to be invoked when a seek operation has been
-   * completed.
-   */
-  var onSeekCompleteListener: MediaPlayer.OnSeekCompleteListener? = null
-
-  /**
-   * Register a callback to be invoked when an error occurs
-   * during playback or setup.  If no listener is specified,
-   * or if the listener returned false, TextureVideoView will inform
-   * the user of any errors.
-   */
-  var onErrorListener: MediaPlayer.OnErrorListener? = null
-
-  /**
-   * Register a callback to be invoked when an informational event
-   * occurs during playback or setup.
-   */
-  var onInfoListener: MediaPlayer.OnInfoListener? = null
+  private var surfaceCallback = SurfaceCallback()
 
   override var volume: Float
-    get() = requestedVolume
+    get() = mediaPlayer.volume
     set(value) {
-      requestedVolume = value
-      mediaPlayer.setVolume(value, value)
+      mediaPlayer.volume = value
     }
 
   override val duration: Long
-    get() = if (_listenerMux?.isPrepared != true || !isReady) {
-      0
-    } else mediaPlayer.duration.toLong()
+    get() = mediaPlayer.duration
 
   override val currentPosition: Long
-    get() = if (_listenerMux?.isPrepared != true || !isReady) {
-      0
-    } else mediaPlayer.currentPosition.toLong()
+    get() = mediaPlayer.currentPosition
 
   override val isPlaying: Boolean
-    get() = isReady && mediaPlayer.isPlaying
+    get() = mediaPlayer.playing
 
   override val bufferedPercent: Int
-    get() = currentBufferPercent
+    get() = mediaPlayer.bufferedPercent
 
   override var drmSessionManagerProvider: DrmSessionManagerProvider?
     get() = null
@@ -132,79 +62,34 @@ class NativeVideoPlayer(
   override val windowInfo: WindowInfo?
     get() = null
 
-  // Marshmallow+ support setting the playback speed natively
   override val playbackSpeed: Float
-    get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      mediaPlayer.playbackParams.speed
-    } else 1f
-
-  protected val isReady: Boolean
-    get() = currentState != State.ERROR && currentState != State.IDLE && currentState != State.PREPARING
-
-  enum class State {
-    ERROR,
-    IDLE,
-    PREPARING,
-    PREPARED,
-    PLAYING,
-    PAUSED,
-    COMPLETED
-  }
+    get() = mediaPlayer.playbackSpeed
 
   init {
-    currentState = State.IDLE
     surface.addCallback(surfaceCallback)
   }
 
   override fun setListenerMux(listenerMux: ListenerMux) {
     _listenerMux = listenerMux
-
-    onCompletionListener = listenerMux
-    onCompletionListener = listenerMux
-    onPreparedListener = listenerMux
-    onBufferingUpdateListener = listenerMux
-    onSeekCompleteListener = listenerMux
-    onErrorListener = listenerMux
+    mediaPlayer.setListener(listenerMux)
   }
 
   override fun start() {
-    if (isReady) {
-      mediaPlayer.start()
-      currentState = State.PLAYING
-    }
-
-    playRequested = true
+    mediaPlayer.start()
     _listenerMux?.setNotifiedCompleted(false)
   }
 
   override fun pause() {
-    if (isReady && mediaPlayer.isPlaying) {
-      mediaPlayer.pause()
-      currentState = State.PAUSED
-    }
-
-    playRequested = false
+    mediaPlayer.pause()
   }
 
   override fun seekTo(milliseconds: Long) {
-    if (isReady) {
-      mediaPlayer.seekTo(milliseconds.toInt())
-      requestedSeek = 0
-    } else {
-      requestedSeek = milliseconds
-    }
+    mediaPlayer.seekTo(milliseconds)
   }
 
   override fun setPlaybackSpeed(speed: Float): Boolean {
-    // Marshmallow+ support setting the playback speed natively
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      mediaPlayer.playbackParams = PlaybackParams().apply {
-        this.speed = speed
-      }
-      return true
-    }
-
-    return false
+    mediaPlayer.playbackSpeed = speed
+    return true
   }
 
   override fun stop() {
@@ -216,18 +101,7 @@ class NativeVideoPlayer(
   }
 
   override fun stop(clearSurface: Boolean) {
-    currentState = State.IDLE
-
-    if (isReady) {
-      try {
-        mediaPlayer.stop()
-      } catch (e: Exception) {
-        Log.d(ContentValues.TAG, "stopPlayback: error calling mediaPlayer.stop()", e)
-      }
-
-    }
-
-    playRequested = false
+    mediaPlayer.stop()
     if (clearSurface) {
       _listenerMux?.clearSurfaceWhenReady(surface)
     }
@@ -238,16 +112,7 @@ class NativeVideoPlayer(
    * destroying the video view
    */
   override fun release() {
-    currentState = State.IDLE
-
-    try {
-      mediaPlayer.reset()
-      mediaPlayer.release()
-    } catch (e: Exception) {
-      Log.d(ContentValues.TAG, "stopPlayback: error calling mediaPlayer.reset() or mediaPlayer.release()", e)
-    }
-
-    playRequested = false
+    mediaPlayer.release()
     surface.removeCallback(surfaceCallback)
   }
 
@@ -256,12 +121,9 @@ class NativeVideoPlayer(
   }
 
   override fun restart(): Boolean {
-    if (currentState != State.COMPLETED) {
+    if (!mediaPlayer.restart()) {
       return false
     }
-
-    seekTo(0)
-    start()
 
     //Makes sure the listeners get the onPrepared callback
     _listenerMux?.setNotifiedPrepared(false)
@@ -294,71 +156,40 @@ class NativeVideoPlayer(
     return false
   }
 
-  override fun setAudioStreamType(streamType: Int) {
-    mediaPlayer.setAudioStreamType(streamType)
+  override fun setAudioAttributes(attributes: AudioAttributes) {
+    mediaPlayer.setAudioAttributes(attributes)
   }
 
   override fun setWakeLevel(levelAndFlags: Int) {
-    mediaPlayer.setWakeMode(context, levelAndFlags)
-  }
-
-  override fun onMediaPrepared() {
-    TODO("Start playback?")
+    mediaPlayer.setWakeLevel(levelAndFlags)
   }
 
   override fun setRepeatMode(repeatMode: Int) {
     // Not Supported
   }
 
-  fun onSurfaceSizeChanged(width: Int, height: Int) {
-    if (width <= 0 || height <= 0) {
-      return
-    }
-
-    if (requestedSeek != 0L) {
-      seekTo(requestedSeek)
-    }
-
-    if (playRequested) {
-      start()
-    }
-  }
-
-  fun onSurfaceReady(surface: Surface?) {
-    mediaPlayer.setSurface(surface)
-    if (playRequested && surface != null) {
-      start()
-    }
-  }
-
   override fun setMedia(uri: Uri?, mediaSource: MediaSource?) {
-    if (uri == null) {
-      return
-    }
+    mediaPlayer.setMedia(uri)
 
-    currentBufferPercent = 0
-
-    try {
-      mediaPlayer.reset()
-      mediaPlayer.setDataSource(context.applicationContext, uri, headers)
-      mediaPlayer.prepareAsync()
-
-      currentState = State.PREPARING
-    } catch (ex: IOException) {
-      Log.w(ContentValues.TAG, "Unable to open content: $uri", ex)
-      currentState = State.ERROR
-
-      internalListeners.onError(mediaPlayer, MediaPlayer.MEDIA_ERROR_UNKNOWN, 0)
-    } catch (ex: IllegalArgumentException) {
-      Log.w(ContentValues.TAG, "Unable to open content: $uri", ex)
-      currentState = State.ERROR
-      internalListeners.onError(mediaPlayer, MediaPlayer.MEDIA_ERROR_UNKNOWN, 0)
-    }
+    //Makes sure the listeners get the onPrepared callback
+    _listenerMux?.setNotifiedPrepared(false)
   }
 
-  protected inner class SurfaceCallback : SurfaceEnvelope.Callback {
+  @Suppress("SameParameterValue")
+  private fun getAudioAttributes(@C.AudioUsage usage: Int, @C.AudioContentType contentType: Int): AudioAttributes {
+    return AudioAttributes.Builder()
+      .setUsage(usage)
+      .setContentType(contentType)
+      .build()
+  }
+
+  private inner class SurfaceCallback : SurfaceEnvelope.Callback {
     override fun onSurfaceAvailable(envelope: SurfaceEnvelope) {
-      onSurfaceReady(envelope.getSurface())
+      mediaPlayer.surface = envelope.getSurface()
+
+      if (mediaPlayer.playWhenReady) {
+        mediaPlayer.start()
+      }
     }
 
     override fun onSurfaceDestroyed(envelope: SurfaceEnvelope) {
@@ -367,61 +198,9 @@ class NativeVideoPlayer(
     }
 
     override fun onSurfaceSizeChanged(envelope: SurfaceEnvelope, width: Int, height: Int) {
-      this@NativeVideoPlayer.onSurfaceSizeChanged(width, height)
-    }
-  }
-
-  inner class InternalListeners :
-    MediaPlayer.OnBufferingUpdateListener,
-    MediaPlayer.OnErrorListener,
-    MediaPlayer.OnPreparedListener,
-    MediaPlayer.OnCompletionListener,
-    MediaPlayer.OnSeekCompleteListener,
-    MediaPlayer.OnInfoListener,
-    MediaPlayer.OnVideoSizeChangedListener {
-    override fun onBufferingUpdate(mp: MediaPlayer, percent: Int) {
-      currentBufferPercent = percent
-      onBufferingUpdateListener?.onBufferingUpdate(mp, percent)
-    }
-
-    override fun onCompletion(mp: MediaPlayer) {
-      currentState = State.COMPLETED
-      onCompletionListener?.onCompletion(mediaPlayer)
-    }
-
-    override fun onSeekComplete(mp: MediaPlayer) {
-      onSeekCompleteListener?.onSeekComplete(mp)
-    }
-
-    override fun onError(mp: MediaPlayer?, what: Int, extra: Int): Boolean {
-      Log.d(ContentValues.TAG, "Error: $what,$extra")
-      currentState = State.ERROR
-
-      return onErrorListener?.onError(mediaPlayer, what, extra) == true
-    }
-
-    override fun onPrepared(mp: MediaPlayer) {
-      currentState = State.PREPARED
-      onPreparedListener?.onPrepared(mediaPlayer)
-
-      // TODO: why does the ExoVideoPlayer not do this
-      surface.setVideoSize(mp.videoWidth, mp.videoHeight)
-
-      if (requestedSeek != 0L) {
-        seekTo(requestedSeek)
-      }
-
-      if (playRequested) {
+      if (width > 0 && height > 0) {
         start()
       }
-    }
-
-    override fun onInfo(mp: MediaPlayer, what: Int, extra: Int): Boolean {
-      return onInfoListener?.onInfo(mp, what, extra) == true
-    }
-
-    override fun onVideoSizeChanged(mp: MediaPlayer, width: Int, height: Int) {
-      surface.setVideoSize(mp.videoWidth, mp.videoHeight)
     }
   }
 }

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/nmp/ExoMediaPlayer.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/nmp/ExoMediaPlayer.kt
@@ -4,19 +4,20 @@ import android.net.Uri
 import android.os.PowerManager
 import android.view.Surface
 import androidx.annotation.IntRange
+import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.Player
+import androidx.media3.exoplayer.analytics.AnalyticsListener
+import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.TrackGroupArray
 import com.devbrackets.android.exomedia.core.listener.CaptionListener
-import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
 import com.devbrackets.android.exomedia.core.listener.ExoPlayerListener
 import com.devbrackets.android.exomedia.core.listener.MetadataListener
 import com.devbrackets.android.exomedia.core.listener.VideoSizeListener
 import com.devbrackets.android.exomedia.core.renderer.RendererType
 import com.devbrackets.android.exomedia.listener.OnBufferUpdateListener
-import androidx.media3.exoplayer.analytics.AnalyticsListener
-import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
-import androidx.media3.exoplayer.source.MediaSource
-import androidx.media3.exoplayer.source.TrackGroupArray
+import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
 
 
 interface ExoMediaPlayer {
@@ -233,7 +234,10 @@ interface ExoMediaPlayer {
   /**
    * Specifies the [C.StreamType] for the player
    */
+  @Deprecated("Use setAudioAttributes instead")
   fun setAudioStreamType(@C.StreamType streamType: Int)
+
+  fun setAudioAttributes(attributes: AudioAttributes)
 
   /**
    * This function has the MediaPlayer access the low-level power manager

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/nmp/ExoMediaPlayerImpl.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/nmp/ExoMediaPlayerImpl.kt
@@ -1,14 +1,18 @@
 package com.devbrackets.android.exomedia.nmp
 
 import android.net.Uri
-import androidx.annotation.FloatRange
 import android.util.Log
 import android.view.Surface
+import androidx.annotation.FloatRange
 import androidx.media3.common.*
 import androidx.media3.common.util.Util
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.analytics.AnalyticsListener
+import androidx.media3.exoplayer.drm.DefaultDrmSessionManagerProvider
+import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.TrackGroupArray
 import com.devbrackets.android.exomedia.core.listener.CaptionListener
-import com.devbrackets.android.exomedia.nmp.manager.StateStore
-import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
 import com.devbrackets.android.exomedia.core.listener.ExoPlayerListener
 import com.devbrackets.android.exomedia.core.listener.MetadataListener
 import com.devbrackets.android.exomedia.core.listener.VideoSizeListener
@@ -16,11 +20,8 @@ import com.devbrackets.android.exomedia.core.renderer.RendererType
 import com.devbrackets.android.exomedia.core.source.builder.MediaSourceBuilder
 import com.devbrackets.android.exomedia.listener.OnBufferUpdateListener
 import com.devbrackets.android.exomedia.nmp.config.PlayerConfig
-import androidx.media3.exoplayer.*
-import androidx.media3.exoplayer.analytics.AnalyticsListener
-import androidx.media3.exoplayer.drm.*
-import androidx.media3.exoplayer.source.MediaSource
-import androidx.media3.exoplayer.source.TrackGroupArray
+import com.devbrackets.android.exomedia.nmp.manager.StateStore
+import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.fixedRateTimer
@@ -223,6 +224,7 @@ class ExoMediaPlayerImpl(
     exoPlayer.clearVideoSurface()
   }
 
+  @Deprecated("Use setAudioAttributes instead")
   override fun setAudioStreamType(streamType: Int) {
     val usage = Util.getAudioUsageForStreamType(streamType)
     val contentType = Util.getAudioContentTypeForStreamType(streamType)
@@ -232,7 +234,11 @@ class ExoMediaPlayerImpl(
       .setContentType(contentType)
       .build()
 
-    exoPlayer.setAudioAttributes(audioAttributes, false)
+    setAudioAttributes(audioAttributes)
+  }
+
+  override fun setAudioAttributes(attributes: AudioAttributes) {
+    exoPlayer.setAudioAttributes(attributes, false)
   }
 
   override fun clearSelectedTracks(type: RendererType) {

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/ui/widget/VideoView.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/ui/widget/VideoView.kt
@@ -16,18 +16,28 @@ import android.widget.RelativeLayout
 import androidx.annotation.DrawableRes
 import androidx.annotation.IntRange
 import androidx.media3.common.Player
+import androidx.media3.exoplayer.analytics.AnalyticsListener
+import androidx.media3.exoplayer.drm.DrmSessionManager
+import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.TrackGroupArray
 import com.devbrackets.android.exomedia.R
 import com.devbrackets.android.exomedia.core.ListenerMux
-import com.devbrackets.android.exomedia.core.video.VideoPlayerApi
-import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
 import com.devbrackets.android.exomedia.core.listener.CaptionListener
 import com.devbrackets.android.exomedia.core.listener.MetadataListener
 import com.devbrackets.android.exomedia.core.renderer.RendererType
 import com.devbrackets.android.exomedia.core.video.ExoVideoPlayer
+import com.devbrackets.android.exomedia.core.video.VideoPlayerApi
+import com.devbrackets.android.exomedia.core.video.layout.AspectRatioLayout
+import com.devbrackets.android.exomedia.core.video.scale.MatrixManager
 import com.devbrackets.android.exomedia.core.video.scale.ScaleType
+import com.devbrackets.android.exomedia.core.video.surface.SurfaceEnvelope
+import com.devbrackets.android.exomedia.core.video.surface.SurfaceViewSurfaceEnvelope
+import com.devbrackets.android.exomedia.core.video.surface.TextureViewSurfaceEnvelope
 import com.devbrackets.android.exomedia.listener.*
 import com.devbrackets.android.exomedia.nmp.ExoMediaPlayer
 import com.devbrackets.android.exomedia.nmp.config.PlayerConfig
+import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
 import com.devbrackets.android.exomedia.ui.widget.attr.VideoViewAttributeParser
 import com.devbrackets.android.exomedia.ui.widget.attr.VideoViewAttributes
 import com.devbrackets.android.exomedia.ui.widget.controls.VideoControls
@@ -35,17 +45,6 @@ import com.devbrackets.android.exomedia.ui.widget.controls.VideoControlsLeanback
 import com.devbrackets.android.exomedia.ui.widget.controls.VideoControlsMobile
 import com.devbrackets.android.exomedia.util.StopWatch
 import com.devbrackets.android.exomedia.util.isDeviceTV
-import androidx.media3.exoplayer.analytics.AnalyticsListener
-import androidx.media3.exoplayer.drm.DrmSessionManager
-import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
-import androidx.media3.exoplayer.source.MediaSource
-import androidx.media3.exoplayer.source.TrackGroupArray
-import com.devbrackets.android.exomedia.core.video.layout.AspectRatioLayout
-import com.devbrackets.android.exomedia.core.video.scale.MatrixManager
-import com.devbrackets.android.exomedia.core.video.surface.SurfaceEnvelope
-import com.devbrackets.android.exomedia.core.video.surface.SurfaceViewSurfaceEnvelope
-import com.devbrackets.android.exomedia.core.video.surface.TextureViewSurfaceEnvelope
-import java.lang.IllegalArgumentException
 
 /**
  * This is a support VideoView that will use the standard VideoView on devices below

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/util/FallbackManager.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/util/FallbackManager.kt
@@ -2,7 +2,6 @@ package com.devbrackets.android.exomedia.util
 
 import android.content.Context
 import android.os.Build
-import android.view.View
 import com.devbrackets.android.exomedia.core.audio.AudioPlayerApi
 import com.devbrackets.android.exomedia.core.video.VideoPlayerApi
 import com.devbrackets.android.exomedia.core.video.surface.SurfaceEnvelope


### PR DESCRIPTION
- [x] This pull request follows the coding standards

### Adds
 - Created a `FallbackMediaPlayer` that handles the "native" fallback media playback using the system `MediaPlayer`. This standardization better allows us to track the playback state (useful for #257) and keep the handling consistent between the Video and Audio players