### PR TITLE
Media3 Wrappers

### DIFF
--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/AudioPlayer.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/AudioPlayer.kt
@@ -22,11 +22,13 @@ import com.devbrackets.android.exomedia.nmp.config.PlayerConfigBuilder
  * fallback to using the OS MediaPlayer.
  */
 @Suppress("MemberVisibilityCanBePrivate", "unused")
-open class AudioPlayer(protected val audioPlayerImpl: AudioPlayerApi) : AudioPlayerApi by audioPlayerImpl {
+open class AudioPlayer(
+  protected val audioPlayerImpl: AudioPlayerApi
+) : AudioPlayerApi by audioPlayerImpl {
   companion object {
     fun getPlayerImplementation(config: PlayerConfig): AudioPlayerApi {
       return if(config.fallbackManager.useFallback()) {
-        config.fallbackManager.getFallbackAudioPlayer(config.context)
+        config.fallbackManager.getFallbackAudioPlayer(config)
       } else {
         ExoAudioPlayer(config)
       }

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/core/audio/AudioPlayerApi.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/core/audio/AudioPlayerApi.kt
@@ -4,10 +4,12 @@ import androidx.annotation.FloatRange
 import androidx.annotation.IntRange
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.Player
+import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.source.TrackGroupArray
 import com.devbrackets.android.exomedia.core.ListenerMux
 import com.devbrackets.android.exomedia.core.renderer.RendererType
+import com.devbrackets.android.exomedia.nmp.config.PlayerConfig
 import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
 
 /**
@@ -17,6 +19,12 @@ import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
  * using the ExoPlayer.
  */
 interface AudioPlayerApi {
+
+  /**
+   * Player configuration information for consistent media construction and
+   * playback.
+   */
+  val playerConfig: PlayerConfig
 
   /**
    * Returns if a media item is currently in playback
@@ -72,6 +80,11 @@ interface AudioPlayerApi {
    * @return The current playback speed
    */
   val playbackSpeed: Float
+
+  /**
+   * Retrieves the correction applied to the audio pitch.
+   */
+  val playbackPitch: Float
 
   /**
    * Retrieves a list of available tracks to select from.  Typically [.trackSelectionAvailable]
@@ -142,6 +155,15 @@ interface AudioPlayerApi {
   fun setPlaybackSpeed(speed: Float): Boolean
 
   /**
+   * Sets the correction to use for the audio pitch. It's recommended to set the pitch
+   * correction to the same amount as the [playbackSpeed] (see [setPlaybackSpeed])
+   *
+   * @param pitch The correction for the audio pitch
+   * @return True if the pitch was set
+   */
+  fun setPlaybackPitch(pitch: Float): Boolean
+
+  /**
    * Sets the audio attributes for this [AudioPlayerApi].
    * You must call this method before loading media with [setMedia] in order
    * for the audio attributes to become effective.
@@ -149,6 +171,14 @@ interface AudioPlayerApi {
    * @param attributes The [AudioAttributes] to apply
    */
   fun setAudioAttributes(attributes: AudioAttributes)
+
+  /**
+   * Sets the [TrackSelectionParameters] for controlling the track selection. This can be
+   * used for defaults like audio language, picture quality, etc.
+   *
+   * @param parameters The [TrackSelectionParameters] to use for track selection
+   */
+  fun setTrackSelectionParameters(parameters: TrackSelectionParameters)
 
   /**
    * Determines if the current video player implementation supports

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/core/audio/ExoAudioPlayer.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/core/audio/ExoAudioPlayer.kt
@@ -4,6 +4,7 @@ import androidx.annotation.IntRange
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.Metadata
 import androidx.media3.common.Player
+import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.source.TrackGroupArray
 import com.devbrackets.android.exomedia.core.ListenerMux
@@ -33,6 +34,9 @@ open class ExoAudioPlayer(protected val config: PlayerConfig) : AudioPlayerApi {
       corePlayer.volume = value
     }
 
+  override val playerConfig: PlayerConfig
+    get() = config
+
   override val isPlaying: Boolean
     get() = corePlayer.playWhenReady
 
@@ -57,6 +61,9 @@ open class ExoAudioPlayer(protected val config: PlayerConfig) : AudioPlayerApi {
 
   override val playbackSpeed: Float
     get() = corePlayer.playbackSpeed
+
+  override val playbackPitch: Float
+    get() = corePlayer.playbackPitch
 
   override val availableTracks: Map<RendererType, TrackGroupArray>?
     get() = corePlayer.availableTracks
@@ -141,6 +148,11 @@ open class ExoAudioPlayer(protected val config: PlayerConfig) : AudioPlayerApi {
     return true
   }
 
+  override fun setPlaybackPitch(pitch: Float): Boolean {
+    corePlayer.playbackPitch = pitch
+    return true
+  }
+
   override fun setAudioAttributes(attributes: AudioAttributes) {
     corePlayer.setAudioAttributes(attributes)
   }
@@ -151,6 +163,10 @@ open class ExoAudioPlayer(protected val config: PlayerConfig) : AudioPlayerApi {
 
   override fun trackSelectionAvailable(): Boolean {
     return true
+  }
+
+  override fun setTrackSelectionParameters(parameters: TrackSelectionParameters) {
+    corePlayer.setTrackSelectionParameters(parameters)
   }
 
   override fun setSelectedTrack(type: RendererType, groupIndex: Int, trackIndex: Int) {

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/core/video/ExoVideoPlayer.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/core/video/ExoVideoPlayer.kt
@@ -4,6 +4,7 @@ import android.view.Surface
 import androidx.annotation.IntRange
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.Metadata
+import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.VideoSize
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.source.TrackGroupArray
@@ -20,11 +21,11 @@ import com.devbrackets.android.exomedia.nmp.config.PlayerConfig
 import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
 
 class ExoVideoPlayer(
-  private val playerConfig: PlayerConfig,
+  private val config: PlayerConfig,
   private val surface: SurfaceEnvelope
 ) : VideoPlayerApi {
   val corePlayer: ExoMediaPlayerImpl by lazy {
-    ExoMediaPlayerImpl(playerConfig).apply {
+    ExoMediaPlayerImpl(config).apply {
       setMetadataListener(internalListeners)
       setBufferUpdateListener(internalListeners)
       setVideoSizeListener(internalListeners)
@@ -43,6 +44,9 @@ class ExoVideoPlayer(
     set(value) {
       corePlayer.volume = value
     }
+
+  override val playerConfig: PlayerConfig
+    get() = config
 
   override val isPlaying: Boolean
     get() = corePlayer.playWhenReady
@@ -71,6 +75,9 @@ class ExoVideoPlayer(
 
   override val playbackSpeed: Float
     get() = corePlayer.playbackSpeed
+
+  override val playbackPitch: Float
+    get() = corePlayer.playbackPitch
 
   override var drmSessionManagerProvider: DrmSessionManagerProvider?
     get() = corePlayer.drmSessionManagerProvider
@@ -163,6 +170,10 @@ class ExoVideoPlayer(
     return true
   }
 
+  override fun setTrackSelectionParameters(parameters: TrackSelectionParameters) {
+    corePlayer.setTrackSelectionParameters(parameters)
+  }
+
   override fun setCaptionListener(listener: CaptionListener?) {
     corePlayer.setCaptionListener(listener)
   }
@@ -198,6 +209,11 @@ class ExoVideoPlayer(
 
   override fun setPlaybackSpeed(speed: Float): Boolean {
     corePlayer.playbackSpeed = speed
+    return true
+  }
+
+  override fun setPlaybackPitch(pitch: Float): Boolean {
+    corePlayer.playbackPitch = pitch
     return true
   }
 

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/fallback/audio/NativeAudioPlayer.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/fallback/audio/NativeAudioPlayer.kt
@@ -1,13 +1,11 @@
 package com.devbrackets.android.exomedia.fallback.audio
 
-import android.content.Context
-import android.net.Uri
 import androidx.annotation.IntRange
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.Player
+import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
-import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.TrackGroupArray
 import com.devbrackets.android.exomedia.core.ListenerMux
 import com.devbrackets.android.exomedia.core.audio.AudioPlayerApi
@@ -15,15 +13,16 @@ import com.devbrackets.android.exomedia.core.audio.MediaItem
 import com.devbrackets.android.exomedia.core.renderer.RendererType
 import com.devbrackets.android.exomedia.fallback.FallbackMediaPlayer
 import com.devbrackets.android.exomedia.fallback.FallbackMediaPlayerImpl
+import com.devbrackets.android.exomedia.nmp.config.PlayerConfig
 import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
 
 /**
  * A simple [AudioPlayerApi] implementation that uses the fallback (system) MediaPlayer
  * to add integration with the [ListenerMux] and to mitigate state errors.
  */
-class NativeAudioPlayer(context: Context) : AudioPlayerApi {
+class NativeAudioPlayer(private val config: PlayerConfig) : AudioPlayerApi {
   private val mediaPlayer: FallbackMediaPlayer by lazy {
-    FallbackMediaPlayerImpl(context).apply {
+    FallbackMediaPlayerImpl(config.context).apply {
       setAudioAttributes(getAudioAttributes(C.USAGE_MEDIA, C.AUDIO_CONTENT_TYPE_MUSIC))
     }
   }
@@ -37,6 +36,9 @@ class NativeAudioPlayer(context: Context) : AudioPlayerApi {
     set(value) {
       mediaPlayer.volume = value
     }
+
+  override val playerConfig: PlayerConfig
+    get() = config
 
   override val isPlaying: Boolean
     get() = mediaPlayer.playing
@@ -55,6 +57,9 @@ class NativeAudioPlayer(context: Context) : AudioPlayerApi {
 
   override val playbackSpeed: Float
     get() = mediaPlayer.playbackSpeed
+
+  override val playbackPitch: Float
+    get() = mediaPlayer.playbackPitch
 
   override val availableTracks: Map<RendererType, TrackGroupArray>?
     get() = null
@@ -113,6 +118,11 @@ class NativeAudioPlayer(context: Context) : AudioPlayerApi {
     return true
   }
 
+  override fun setPlaybackPitch(pitch: Float): Boolean {
+    mediaPlayer.playbackPitch = pitch
+    return true
+  }
+
   override fun setAudioAttributes(attributes: AudioAttributes) {
     mediaPlayer.setAudioAttributes(attributes)
   }
@@ -123,6 +133,10 @@ class NativeAudioPlayer(context: Context) : AudioPlayerApi {
 
   override fun trackSelectionAvailable(): Boolean {
     return false
+  }
+
+  override fun setTrackSelectionParameters(parameters: TrackSelectionParameters) {
+    // Not supported
   }
 
   override fun setSelectedTrack(type: RendererType, groupIndex: Int, trackIndex: Int) {

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/fallback/video/NativeVideoPlayer.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/fallback/video/NativeVideoPlayer.kt
@@ -1,8 +1,8 @@
 package com.devbrackets.android.exomedia.fallback.video
 
-import android.content.Context
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.source.TrackGroupArray
 import com.devbrackets.android.exomedia.core.ListenerMux
@@ -13,15 +13,16 @@ import com.devbrackets.android.exomedia.core.video.VideoPlayerApi
 import com.devbrackets.android.exomedia.core.video.surface.SurfaceEnvelope
 import com.devbrackets.android.exomedia.fallback.FallbackMediaPlayer
 import com.devbrackets.android.exomedia.fallback.FallbackMediaPlayerImpl
+import com.devbrackets.android.exomedia.nmp.config.PlayerConfig
 import com.devbrackets.android.exomedia.nmp.manager.window.WindowInfo
 
 class NativeVideoPlayer(
-  private var context: Context,
+  private val config: PlayerConfig,
   private val surface: SurfaceEnvelope
 ) : VideoPlayerApi {
 
   private val mediaPlayer: FallbackMediaPlayer by lazy {
-    FallbackMediaPlayerImpl(context).apply {
+    FallbackMediaPlayerImpl(config.context).apply {
       setAudioAttributes(getAudioAttributes(C.USAGE_MEDIA, C.AUDIO_CONTENT_TYPE_MOVIE))
     }
   }
@@ -41,6 +42,9 @@ class NativeVideoPlayer(
 
   override val currentPosition: Long
     get() = mediaPlayer.currentPosition
+
+  override val playerConfig: PlayerConfig
+    get() = config
 
   override val isPlaying: Boolean
     get() = mediaPlayer.playing
@@ -63,6 +67,9 @@ class NativeVideoPlayer(
 
   override val playbackSpeed: Float
     get() = mediaPlayer.playbackSpeed
+
+  override val playbackPitch: Float
+    get() = mediaPlayer.playbackPitch
 
   init {
     surface.addCallback(surfaceCallback)
@@ -88,6 +95,11 @@ class NativeVideoPlayer(
 
   override fun setPlaybackSpeed(speed: Float): Boolean {
     mediaPlayer.playbackSpeed = speed
+    return true
+  }
+
+  override fun setPlaybackPitch(pitch: Float): Boolean {
+    mediaPlayer.playbackPitch = pitch
     return true
   }
 
@@ -133,6 +145,10 @@ class NativeVideoPlayer(
 
   override fun trackSelectionAvailable(): Boolean {
     return false
+  }
+
+  override fun setTrackSelectionParameters(parameters: TrackSelectionParameters) {
+    // Not supported
   }
 
   override fun setSelectedTrack(type: RendererType, groupIndex: Int, trackIndex: Int) {

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/nmp/ExoMediaPlayer.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/nmp/ExoMediaPlayer.kt
@@ -7,6 +7,7 @@ import androidx.annotation.IntRange
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.Player
+import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.source.MediaSource
@@ -195,6 +196,14 @@ interface ExoMediaPlayer {
    * @param trackIndex The index within the `groupIndex` to select
    */
   fun setSelectedTrack(type: RendererType, groupIndex: Int, trackIndex: Int)
+
+  /**
+   * Sets the [TrackSelectionParameters] for controlling the track selection. This can be
+   * used for defaults like audio language, picture quality, etc.
+   *
+   * @param parameters The [TrackSelectionParameters] to use for track selection
+   */
+  fun setTrackSelectionParameters(parameters: TrackSelectionParameters)
 
   /**
    * Retrieves the active/selected track index for the specified [RendererType] and

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/nmp/ExoMediaPlayerImpl.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/nmp/ExoMediaPlayerImpl.kt
@@ -4,7 +4,9 @@ import android.net.Uri
 import android.util.Log
 import android.view.Surface
 import androidx.annotation.FloatRange
+import androidx.annotation.OptIn
 import androidx.media3.common.*
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
@@ -28,6 +30,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.min
 
+@OptIn(UnstableApi::class)
 class ExoMediaPlayerImpl(
   private val config: PlayerConfig
 ) : Player.Listener, ExoMediaPlayer {
@@ -394,6 +397,10 @@ class ExoMediaPlayerImpl(
 
   override fun setRepeatMode(@Player.RepeatMode repeatMode: Int) {
     exoPlayer.repeatMode = repeatMode
+  }
+
+  override fun setTrackSelectionParameters(parameters: TrackSelectionParameters) {
+    config.trackManager.setTrackSelectionParameters(parameters)
   }
 
   override fun setSelectedTrack(type: RendererType, groupIndex: Int, trackIndex: Int) {

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/nmp/manager/track/TrackManager.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/nmp/manager/track/TrackManager.kt
@@ -2,22 +2,24 @@ package com.devbrackets.android.exomedia.nmp.manager.track
 
 import android.content.Context
 import android.util.ArrayMap
+import androidx.annotation.OptIn
 import androidx.media3.common.C
 import androidx.media3.common.TrackGroup
-import com.devbrackets.android.exomedia.core.renderer.RendererType
+import androidx.media3.common.TrackSelectionParameters
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.source.TrackGroupArray
 import androidx.media3.exoplayer.trackselection.AdaptiveTrackSelection
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.trackselection.MappingTrackSelector
-import java.util.ArrayList
+import com.devbrackets.android.exomedia.core.renderer.RendererType
 
 /**
- * Handles managing the tracks for the [CorePlayer]
+ * Handles managing the tracks for the [com.devbrackets.android.exomedia.nmp.ExoMediaPlayerImpl]
  */
+@OptIn(UnstableApi::class)
 class TrackManager(context: Context) {
   private val selectionFactory: AdaptiveTrackSelection.Factory = AdaptiveTrackSelection.Factory()
   val selector: DefaultTrackSelector = DefaultTrackSelector(context, selectionFactory)
-
 
   /**
    * Retrieves a list of available tracks
@@ -84,6 +86,10 @@ class TrackManager(context: Context) {
     }
 
     return RendererTrackInfo(rendererTrackIndexes, rendererTrackIndex, rendererTrackGroupIndex)
+  }
+
+  fun setTrackSelectionParameters(parameters: TrackSelectionParameters) {
+    selector.setParameters(parameters)
   }
 
   @JvmOverloads

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/ui/widget/VideoView.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/ui/widget/VideoView.kt
@@ -19,6 +19,7 @@ import android.widget.RelativeLayout
 import androidx.annotation.DrawableRes
 import androidx.annotation.IntRange
 import androidx.media3.common.Player
+import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.drm.DrmSessionManager
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
@@ -70,7 +71,7 @@ open class VideoView : RelativeLayout, PlaybackStateListener {
     constructEnvelope(surface)
   }
 
-  protected val videoPlayer: VideoPlayerApi by lazy { getApiImplementation() }
+  val videoPlayer: VideoPlayerApi by lazy { getApiImplementation() }
 
   /**
    * Gets the [MediaItem] currently used. This is specified by calling [setMedia]
@@ -212,6 +213,12 @@ open class VideoView : RelativeLayout, PlaybackStateListener {
    */
   val playbackSpeed: Float
     get() = videoPlayer.playbackSpeed
+
+  /**
+   * Retrieves the correction applied to the audio pitch.
+   */
+  val playbackPitch: Float
+    get() = videoPlayer.playbackPitch
 
   /**
    * Retrieves a list of available tracks to select from. Typically [.trackSelectionAvailable]
@@ -528,7 +535,8 @@ open class VideoView : RelativeLayout, PlaybackStateListener {
   }
 
   /**
-   * Sets the playback speed for this MediaPlayer.
+   * Sets the playback speed for this MediaPlayer. It is recommended that when
+   * you update the playback speed you also apply a pitch correction with [setPlaybackPitch]
    *
    * @param speed The speed to play the media back at
    * @return True if the speed was set
@@ -540,6 +548,17 @@ open class VideoView : RelativeLayout, PlaybackStateListener {
     }
 
     return wasSet
+  }
+
+  /**
+   * Sets the correction to use for the audio pitch. It's recommended to set the pitch
+   * correction to the same amount as the [playbackSpeed] (see [setPlaybackSpeed])
+   *
+   * @param pitch The correction for the audio pitch
+   * @return True if the pitch was set
+   */
+  fun setPlaybackPitch(pitch: Float): Boolean {
+    return videoPlayer.setPlaybackPitch(pitch)
   }
 
   /**
@@ -560,6 +579,16 @@ open class VideoView : RelativeLayout, PlaybackStateListener {
    */
   fun trackSelectionAvailable(): Boolean {
     return videoPlayer.trackSelectionAvailable()
+  }
+
+  /**
+   * Sets the [TrackSelectionParameters] for controlling the track selection. This can be
+   * used for defaults like audio language, picture quality, etc.
+   *
+   * @param parameters The [TrackSelectionParameters] to use for track selection
+   */
+  fun setTrackSelectionParameters(parameters: TrackSelectionParameters) {
+    videoPlayer.setTrackSelectionParameters(parameters)
   }
 
   /**
@@ -802,7 +831,7 @@ open class VideoView : RelativeLayout, PlaybackStateListener {
    */
   fun getApiImplementation(): VideoPlayerApi {
     if (playerConfig.fallbackManager.useFallback()) {
-      return playerConfig.fallbackManager.getFallbackVideoPlayer(context, surfaceEnvelope)
+      return playerConfig.fallbackManager.getFallbackVideoPlayer(playerConfig, surfaceEnvelope)
     }
 
     return ExoVideoPlayer(playerConfig, surfaceEnvelope)

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/unified/AudioPlayerWrapper.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/unified/AudioPlayerWrapper.kt
@@ -1,0 +1,133 @@
+package com.devbrackets.android.exomedia.unified
+
+import androidx.annotation.OptIn
+import androidx.media3.common.*
+import androidx.media3.common.util.UnstableApi
+import com.devbrackets.android.exomedia.AudioPlayer
+import com.devbrackets.android.exomedia.nmp.config.PlayerConfig
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+
+/**
+ * An implementation of the Media3 [Player] that uses the [AudioPlayer] as the backing.
+ *
+ * NOTE:
+ * The [AudioPlayer] doesn't extend the Player interface so that the exposed APIs
+ * are straightforward for simple use-cases.
+ */
+@OptIn(UnstableApi::class)
+open class AudioPlayerWrapper(
+  val audioPlayer: AudioPlayer,
+  private val playerConfig: PlayerConfig = audioPlayer.playerConfig
+): SimpleBasePlayer(playerConfig.handler.looper) {
+  companion object {
+    @JvmStatic
+    val SUPPORTED_AUDIO_COMMANDS = listOf(
+        COMMAND_PLAY_PAUSE,
+        COMMAND_STOP,
+        COMMAND_SEEK_TO_DEFAULT_POSITION,
+        COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM,
+        COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
+        COMMAND_SEEK_TO_PREVIOUS,
+        COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
+        COMMAND_SEEK_TO_NEXT,
+        COMMAND_SEEK_BACK,
+        COMMAND_SEEK_FORWARD,
+        COMMAND_SET_SPEED_AND_PITCH,
+        COMMAND_SET_REPEAT_MODE,
+        COMMAND_GET_CURRENT_MEDIA_ITEM,
+        COMMAND_GET_MEDIA_ITEMS_METADATA,
+        COMMAND_SET_MEDIA_ITEM,
+        COMMAND_GET_AUDIO_ATTRIBUTES,
+        COMMAND_GET_VOLUME,
+        COMMAND_GET_TEXT,
+        COMMAND_SET_TRACK_SELECTION_PARAMETERS,
+        COMMAND_GET_TRACKS
+    )
+  }
+
+  private var playWhenReady: Boolean = false
+
+  override fun getState(): State {
+    val allowedCommands = Player.Commands.Builder().apply {
+      SUPPORTED_AUDIO_COMMANDS.forEach {
+        add(it)
+      }
+    }.build()
+
+    return State.Builder()
+      .setAvailableCommands(allowedCommands)
+      .setPlayWhenReady(playWhenReady, PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST)
+      .build()
+  }
+
+  override fun handleSetPlayWhenReady(playWhenReady: Boolean): ListenableFuture<*> {
+    this.playWhenReady = playWhenReady
+
+    when (playWhenReady) {
+      true -> audioPlayer.start()
+      false -> audioPlayer.pause()
+    }
+
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handlePrepare(): ListenableFuture<*> {
+    // ExoMedia implementations automatically prepare the media
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleStop(): ListenableFuture<*> {
+    this.playWhenReady = false
+    audioPlayer.stop()
+
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleRelease(): ListenableFuture<*> {
+    audioPlayer.release()
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleSetRepeatMode(repeatMode: Int): ListenableFuture<*> {
+    audioPlayer.setRepeatMode(repeatMode)
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleSetPlaybackParameters(playbackParameters: PlaybackParameters): ListenableFuture<*> {
+    audioPlayer.setPlaybackSpeed(playbackParameters.speed)
+    audioPlayer.setPlaybackPitch(playbackParameters.pitch)
+
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleSetTrackSelectionParameters(trackSelectionParameters: TrackSelectionParameters): ListenableFuture<*> {
+    audioPlayer.setTrackSelectionParameters(trackSelectionParameters)
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleSetVolume(volume: Float): ListenableFuture<*> {
+    audioPlayer.volume = volume
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleSetMediaItems(mediaItems: MutableList<MediaItem>, startIndex: Int, startPositionMs: Long): ListenableFuture<*> {
+    // We only support setting a single media item
+    val mediaSource = mediaItems.firstOrNull()?.let {
+      playerConfig.mediaSourceFactory.createMediaSource(it)
+    }
+
+    audioPlayer.setMedia(mediaSource)
+    if (startPositionMs > 0) {
+      audioPlayer.seekTo(startPositionMs)
+    }
+
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleSeek(mediaItemIndex: Int, positionMs: Long, seekCommand: Int): ListenableFuture<*> {
+    // We only support a single media item, so we ignore the index
+    audioPlayer.seekTo(positionMs)
+    return Futures.immediateVoidFuture()
+  }
+}

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/unified/VideoViewWrapper.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/unified/VideoViewWrapper.kt
@@ -1,0 +1,120 @@
+package com.devbrackets.android.exomedia.unified
+
+import androidx.annotation.OptIn
+import androidx.media3.common.*
+import androidx.media3.common.util.UnstableApi
+import com.devbrackets.android.exomedia.nmp.config.PlayerConfig
+import com.devbrackets.android.exomedia.ui.widget.VideoView
+import com.devbrackets.android.exomedia.unified.AudioPlayerWrapper.Companion.SUPPORTED_AUDIO_COMMANDS
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+
+/**
+ * An implementation of the Media3 [Player] that uses the [VideoView] as the backing.
+ *
+ * NOTE:
+ * The [VideoView] doesn't extend the Player interface so that the exposed APIs
+ * are straightforward for simple use-cases.
+ */
+@OptIn(UnstableApi::class)
+open class VideoViewWrapper(
+  val videoView: VideoView,
+  private val playerConfig: PlayerConfig = videoView.videoPlayer.playerConfig
+): SimpleBasePlayer(playerConfig.handler.looper) {
+  companion object {
+    @JvmStatic
+    val SUPPORTED_VIDEO_COMMANDS = listOf<Int>(
+      // TODO: add support for dynamically swapping the video surface (SurfaceEnvelope in the VideoView)
+//      COMMAND_SET_VIDEO_SURFACE
+    )
+  }
+
+  private var playWhenReady: Boolean = false
+
+  override fun getState(): State {
+    val allowedCommands = Player.Commands.Builder().apply {
+      SUPPORTED_AUDIO_COMMANDS.forEach {
+        add(it)
+      }
+
+      SUPPORTED_VIDEO_COMMANDS.forEach {
+        add(it)
+      }
+    }.build()
+
+    return State.Builder()
+      .setAvailableCommands(allowedCommands)
+      .setPlayWhenReady(playWhenReady, PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST)
+      .build()
+  }
+
+  override fun handleSetPlayWhenReady(playWhenReady: Boolean): ListenableFuture<*> {
+    this.playWhenReady = playWhenReady
+
+    when (playWhenReady) {
+      true -> videoView.start()
+      false -> videoView.pause()
+    }
+
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handlePrepare(): ListenableFuture<*> {
+    // ExoMedia implementations automatically prepare the media
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleStop(): ListenableFuture<*> {
+    this.playWhenReady = false
+    videoView.stop()
+
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleRelease(): ListenableFuture<*> {
+    videoView.release()
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleSetRepeatMode(repeatMode: Int): ListenableFuture<*> {
+    videoView.setRepeatMode(repeatMode)
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleSetPlaybackParameters(playbackParameters: PlaybackParameters): ListenableFuture<*> {
+    videoView.setPlaybackSpeed(playbackParameters.speed)
+    videoView.setPlaybackPitch(playbackParameters.pitch)
+
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleSetTrackSelectionParameters(trackSelectionParameters: TrackSelectionParameters): ListenableFuture<*> {
+    videoView.setTrackSelectionParameters(trackSelectionParameters)
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleSetVolume(volume: Float): ListenableFuture<*> {
+    videoView.volume = volume
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleSetMediaItems(mediaItems: MutableList<MediaItem>, startIndex: Int, startPositionMs: Long): ListenableFuture<*> {
+    // We only support setting a single media item
+    val mediaSource = mediaItems.firstOrNull()?.let {
+      playerConfig.mediaSourceFactory.createMediaSource(it)
+    }
+
+    videoView.setMedia(mediaSource)
+    if (startPositionMs > 0) {
+      videoView.seekTo(startPositionMs)
+    }
+
+    return Futures.immediateVoidFuture()
+  }
+
+  override fun handleSeek(mediaItemIndex: Int, positionMs: Long, seekCommand: Int): ListenableFuture<*> {
+    // We only support a single media item, so we ignore the index
+    videoView.seekTo(positionMs)
+    return Futures.immediateVoidFuture()
+  }
+}

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/unified/ext/PlayerExt.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/unified/ext/PlayerExt.kt
@@ -1,0 +1,30 @@
+package com.devbrackets.android.exomedia.unified.ext
+
+import com.devbrackets.android.exomedia.AudioPlayer
+import com.devbrackets.android.exomedia.ui.widget.VideoView
+import com.devbrackets.android.exomedia.unified.AudioPlayerWrapper
+import com.devbrackets.android.exomedia.unified.VideoViewWrapper
+
+/**
+ * Wraps the [VideoView] in a Media3 [androidx.media3.common.Player] to
+ * support integrating with the rest of the Media3 framework for playlists,
+ * player selection, etc.
+ *
+ * @return A Media3 [androidx.media3.common.Player] that uses the [VideoView] as the implementation
+ */
+fun VideoView.asMedia3Player(): VideoViewWrapper {
+  return VideoViewWrapper(this)
+}
+
+
+
+/**
+ * Wraps the [AudioPlayer] in a Media3 [androidx.media3.common.Player] to
+ * support integrating with the rest of the Media3 framework for playlists,
+ * player selection, etc.
+ *
+ * @return A Media3 [androidx.media3.common.Player] that uses the [AudioPlayer] as the implementation
+ */
+fun AudioPlayer.asMedia3Player(): AudioPlayerWrapper {
+  return AudioPlayerWrapper(this)
+}

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/util/FallbackManager.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/util/FallbackManager.kt
@@ -1,12 +1,12 @@
 package com.devbrackets.android.exomedia.util
 
-import android.content.Context
 import android.os.Build
 import com.devbrackets.android.exomedia.core.audio.AudioPlayerApi
 import com.devbrackets.android.exomedia.core.video.VideoPlayerApi
 import com.devbrackets.android.exomedia.core.video.surface.SurfaceEnvelope
 import com.devbrackets.android.exomedia.fallback.audio.NativeAudioPlayer
 import com.devbrackets.android.exomedia.fallback.video.NativeVideoPlayer
+import com.devbrackets.android.exomedia.nmp.config.PlayerConfig
 
 /**
  * Determines if, and provides the fallback media player implementations on
@@ -31,16 +31,16 @@ open class FallbackManager {
    * Retrieves an [AudioPlayerApi] implementation to use in situations where the
    * ExoPlayer isn't supported.
    */
-  open fun getFallbackAudioPlayer(context: Context): AudioPlayerApi {
-    return NativeAudioPlayer(context)
+  open fun getFallbackAudioPlayer(config: PlayerConfig): AudioPlayerApi {
+    return NativeAudioPlayer(config)
   }
 
   /**
    * Retrieves a [VideoPlayerApi] implementation to use in situations where the
    * ExoPlayer isn't supported
    */
-  open fun getFallbackVideoPlayer(context: Context, surface: SurfaceEnvelope): VideoPlayerApi {
-    return NativeVideoPlayer(context, surface)
+  open fun getFallbackVideoPlayer(config: PlayerConfig, surface: SurfaceEnvelope): VideoPlayerApi {
+    return NativeVideoPlayer(config, surface)
   }
 
   data class DeviceModels(


### PR DESCRIPTION

### Updates:
 - Adds a `AudioPlayerWrapper` to expose the `AudioPlayer` to the Media3 framework. This can be manually constructed or through the `.asMedia3Player()` extension on the `AudioPlayer`
 - Adds a `VideoViewWrapper` to expose the `VideoView` to the Media3 framework. This can be manually constructed or through the `.asMedia3Player()` extension on the `VideoView`