### PR TITLE
[#488] Improves handling of Live/Event streams

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 
 ext {
   moduleTestResults = []
-  media3Version = "1.0.0-rc02"
+  media3Version = "1.0.0"
 }
 
 

--- a/demo/src/main/kotlin/com/devbrackets/android/exomediademo/data/Samples.kt
+++ b/demo/src/main/kotlin/com/devbrackets/android/exomediademo/data/Samples.kt
@@ -19,7 +19,6 @@ object Samples {
   val video by lazy {
     listOf(
       videoSample("Big Buck Bunny (MP4)", "https://www.devbrackets.com/media/samples/video/big_buck_bunny.mp4"),
-      videoSample("Big Buck Bunny - Live (MPEG Dash)", "https://wowzaec2demo.streamlock.net/live/bigbuckbunny/manifest_mpm4sav_mvtime.mpd"),
       videoSample("Caminandes (FLV)", "https://www.devbrackets.com/media/samples/video/caminandes_01.flv"),
       videoSample("Caminandes (Smooth Stream)", "http://amssamples.streaming.mediaservices.windows.net/634cd01c-6822-4630-8444-8dd6279f94c6/CaminandesLlamaDrama4K.ism/manifest"),
       videoSample("Caminandes 2 (MP4)", "https://www.devbrackets.com/media/samples/video/caminandes_02.mp4"),
@@ -30,7 +29,8 @@ object Samples {
       videoSample("Elephants Dream (HLS)", "https://www.devbrackets.com/media/samples/video/elephants_dream/elephants_dream.m3u8"),
       videoSample("Sintel (WebM)", "https://www.devbrackets.com/media/samples/video/sintel.webm"),
       videoSample("Sintel (MPEG Dash)", "https://bitdash-a.akamaihd.net/content/sintel/sintel.mpd"),
-      videoSample("Tears of Steel (MP4)", "https://www.devbrackets.com/media/samples/video/tears_of_steel.mp4")
+      videoSample("Tears of Steel (MP4)", "https://www.devbrackets.com/media/samples/video/tears_of_steel.mp4"),
+      videoSample("Tears of Steel - Live (HLS)", "https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/master.m3u8")
     )
   }
 

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/ui/widget/VideoView.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/ui/widget/VideoView.kt
@@ -84,7 +84,7 @@ open class VideoView : RelativeLayout, PlaybackStateListener {
   protected var audioFocusHelper = AudioFocusHelper()
 
   /**
-   * Sets the amount of time to change the return value from [.getCurrentPosition].
+   * Sets the amount of time to change the return value from [currentPosition].
    * This value will be reset when a new audio item is selected.
    */
   var positionOffset: Long = 0
@@ -110,7 +110,7 @@ open class VideoView : RelativeLayout, PlaybackStateListener {
    *
    * Enables or disables the automatic release when the VideoView is detached
    * from the window. Normally this is expected to release all resources used
-   * by calling [.release].  If `releaseOnDetach` is disabled
+   * by calling [release]. If `releaseOnDetach` is disabled
    * then [.release] will need to be manually called.
    */
   var releaseOnDetachFromWindow = true
@@ -164,9 +164,9 @@ open class VideoView : RelativeLayout, PlaybackStateListener {
     get() = videoPlayer.isPlaying
 
   /**
-   * Retrieves the duration of the current audio item.  This should only be called after
-   * the item is prepared (see [.setOnPreparedListener]).
-   * If [.overrideDuration] is set then that value will be returned.
+   * Retrieves the duration of the current audio item. This should only be called after
+   * the item is prepared (see [setOnPreparedListener]).
+   * If [overrideDuration] is set then that value will be returned.
    *
    * @return The millisecond duration of the video
    */
@@ -176,9 +176,9 @@ open class VideoView : RelativeLayout, PlaybackStateListener {
     } else videoPlayer.duration
 
   /**
-   * Retrieves the current position of the audio playback.  If an audio item is not currently
-   * in playback then the value will be 0.  This should only be called after the item is
-   * prepared (see [.setOnPreparedListener])
+   * Retrieves the current position of the audio playback. If an audio item is not currently
+   * in playback then the value will be 0. This should only be called after the item is
+   * prepared (see [setOnPreparedListener])
    *
    * @return The millisecond value for the current position
    */
@@ -188,9 +188,9 @@ open class VideoView : RelativeLayout, PlaybackStateListener {
     } else positionOffset + videoPlayer.currentPosition
 
   /**
-   * Retrieves the current buffer percent of the video.  If a video is not currently
-   * prepared or buffering the value will be 0.  This should only be called after the video is
-   * prepared (see [.setOnPreparedListener])
+   * Retrieves the current buffer percent of the video. If a video is not currently
+   * prepared or buffering the value will be 0. This should only be called after the video is
+   * prepared (see [setOnPreparedListener])
    *
    * @return The integer percent that is buffered [0, 100] inclusive
    */
@@ -229,7 +229,7 @@ open class VideoView : RelativeLayout, PlaybackStateListener {
     get() = videoPlayer.playbackPitch
 
   /**
-   * Retrieves a list of available tracks to select from. Typically [.trackSelectionAvailable]
+   * Retrieves a list of available tracks to select from. Typically [trackSelectionAvailable]
    * should be called before this.
    *
    * @return A list of available tracks associated with each track type

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/ui/widget/controls/VideoControlsMobile.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/ui/widget/controls/VideoControlsMobile.kt
@@ -9,9 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.SeekBar
-import androidx.annotation.IntRange
 import com.devbrackets.android.exomedia.R
-import com.devbrackets.android.exomedia.util.millisToFormattedDuration
 import java.util.*
 
 /**
@@ -19,11 +17,8 @@ import java.util.*
  * on mobile devices (Phone, Tablet, etc.).
  */
 class VideoControlsMobile : DefaultVideoControls {
-  private lateinit var seekBar: SeekBar
   private lateinit var extraViewsContainer: LinearLayout
   private lateinit var container: ViewGroup
-
-  private var userInteracting = false
 
   override val layoutResource: Int
     get() = R.layout.exomedia_controls_mobile
@@ -52,32 +47,6 @@ class VideoControlsMobile : DefaultVideoControls {
     setOnTouchListener(TouchListener(context))
   }
 
-  override fun setPosition(@IntRange(from = 0) position: Long) {
-    seekBar.progress = position.toInt()
-    updateCurrentTime(position)
-  }
-
-  override fun setDuration(@IntRange(from = 0) duration: Long) {
-    super.setDuration(duration)
-    if (duration != seekBar.max.toLong()) {
-      endTimeTextView.text = duration.millisToFormattedDuration()
-      seekBar.max = duration.toInt()
-    }
-  }
-
-  override fun updateProgress(
-    @IntRange(from = 0) position: Long,
-    @IntRange(from = 0) duration: Long,
-    @IntRange(from = 0, to = 100) bufferPercent: Int
-  ) {
-    if (!userInteracting) {
-      seekBar.secondaryProgress = (seekBar.max * (bufferPercent.toFloat() / 100)).toInt()
-      seekBar.progress = position.toInt()
-
-      updateCurrentTime(position)
-    }
-  }
-
   override fun registerListeners() {
     super.registerListeners()
     seekBar.setOnSeekBarChangeListener(SeekBarChanged())
@@ -85,7 +54,6 @@ class VideoControlsMobile : DefaultVideoControls {
 
   override fun retrieveViews() {
     super.retrieveViews()
-    seekBar = findViewById(R.id.exomedia_controls_video_seek)
     extraViewsContainer = findViewById(R.id.exomedia_controls_extra_container)
     container = findViewById(R.id.exomedia_controls_container)
   }
@@ -185,7 +153,7 @@ class VideoControlsMobile : DefaultVideoControls {
       }
 
       seekToTime = progress.toLong()
-      updateCurrentTime(seekToTime)
+      updatePositionText(seekToTime)
     }
 
     override fun onStartTrackingTouch(seekBar: SeekBar) {

--- a/library/src/main/kotlin/com/devbrackets/android/exomedia/ui/widget/controls/VideoControlsTv.kt
+++ b/library/src/main/kotlin/com/devbrackets/android/exomedia/ui/widget/controls/VideoControlsTv.kt
@@ -6,11 +6,9 @@ import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.*
-import androidx.annotation.IntRange
 import androidx.core.view.forEach
 import com.devbrackets.android.exomedia.BuildConfig
 import com.devbrackets.android.exomedia.R
-import com.devbrackets.android.exomedia.util.millisToFormattedDuration
 import com.devbrackets.android.exomedia.util.view.DelegatedOnKeyListener
 import com.devbrackets.android.exomedia.util.view.UnhandledMediaKeyLogger
 import java.util.*
@@ -25,11 +23,8 @@ class VideoControlsTv : DefaultVideoControls {
     private const val TV_CONTROLS_HIDE_DELAY = 5_000L
   }
 
-  private lateinit var seekBar: SeekBar
   private lateinit var extraViewsContainer: LinearLayout
   private lateinit var container: ViewGroup
-
-  private var userInteracting = false
 
   private var rewindEnabled: Boolean = true
   private var fastForwardEnabled: Boolean = true
@@ -62,41 +57,12 @@ class VideoControlsTv : DefaultVideoControls {
     setDefaultHideDelay(TV_CONTROLS_HIDE_DELAY)
     internalListener = TvInternalListener()
     registerForInput()
-
-    seekBar.keyProgressIncrement
   }
 
   override fun retrieveViews() {
     super.retrieveViews()
-    seekBar = findViewById(R.id.exomedia_controls_video_seek)
     extraViewsContainer = findViewById(R.id.exomedia_controls_extra_container)
     container = findViewById(R.id.exomedia_controls_container)
-  }
-
-  override fun setPosition(@IntRange(from = 0) position: Long) {
-    seekBar.progress = position.toInt()
-    updateCurrentTime(position)
-  }
-
-  override fun setDuration(@IntRange(from = 0) duration: Long) {
-    super.setDuration(duration)
-    if (duration != seekBar.max.toLong()) {
-      endTimeTextView.text = duration.millisToFormattedDuration()
-      seekBar.max = duration.toInt()
-    }
-  }
-
-  override fun updateProgress(
-    @IntRange(from = 0) position: Long,
-    @IntRange(from = 0) duration: Long,
-    @IntRange(from = 0, to = 100) bufferPercent: Int
-  ) {
-    if (!userInteracting) {
-      seekBar.secondaryProgress = (seekBar.max * (bufferPercent.toFloat() / 100)).toInt()
-      seekBar.progress = position.toInt()
-
-      updateCurrentTime(position)
-    }
   }
 
   override fun setRewindButtonEnabled(enabled: Boolean) {

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
   <string name="exomedia_controls_accessibility_play_pause">Play or Pause</string>
   <string name="exomedia_controls_accessibility_previous">Previous Media</string>
   <string name="exomedia_controls_accessibility_next">Next Media</string>
+  <string name="exomedia_controls_live">Live</string>
 </resources>


### PR DESCRIPTION
Closes #488

### Updates:
 - Media3 dependencies have been updated to the `1.0.0` release
 - The `DefaultVideoControls` and children now represent Live/Event/VoD streams appropriately

### Fixes: 
 - Video manifest files are now excluded from the file cache in the *demo* app