### PR TITLE
May 2023 Dependency Updates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
  - ExoMedia version: `5.0.0`
  - Device OS version: `12.0`
  - Device Manufacturer: `Google`
- - Device Name: `Pixel 6 Pro`
+ - Device Name: `Pixel 7 Pro`
  
 ### Reproduction Steps
  0.  

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Closes #
+Addresses #
 
 ### Updates:
  - 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'gradle'
       - name: "Build & Test"
         run: ./gradlew clean assembleDebug testDebugUnitTest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     name: "Release"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'gradle'
       - name: "Build & Release"
         run: ./gradlew clean library:assembleRelease androidJavaDocJar androidSourcesJar generatePomFileForNexusPublication publishNexusPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,12 @@
-import org.gradle.internal.logging.text.StyledTextOutputFactory
-import static org.gradle.internal.logging.text.StyledTextOutput.Style
-
 buildscript {
-  ext.kotlinVersion = '1.8.10'
+  ext.kotlinVersion = '1.8.21'
   repositories {
     mavenCentral()
     google()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:7.4.2'
+    classpath 'com.android.tools.build:gradle:8.0.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
   }
 }
@@ -18,80 +15,18 @@ plugins {
   id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 
-ext {
-  moduleTestResults = []
-  media3Version = "1.0.0"
-}
+apply from: './gradle/util/testOutput.gradle'
 
+ext {
+  media3Version = "1.0.1"
+}
 
 allprojects {
   repositories {
     mavenCentral()
     google()
   }
-
-  tasks.withType(Test) {
-    testLogging {
-      outputs.upToDateWhen { false }
-      events "failed", "skipped", "standardOut"
-      exceptionFormat "full"
-
-      afterSuite { desc, result ->
-        if (!desc.parent) {
-          rootProject.moduleTestResults.add([name: project.name, result: result])
-        }
-      }
-    }
-  }
 }
-
-gradle.buildFinished {
-  def testResults = rootProject.ext.moduleTestResults
-  def totals = [success: 0, failed: 0, skipped: 0, total: 0]
-
-  testResults.forEach { result ->
-    totals.success += result.result.successfulTestCount
-    totals.failed += result.result.failedTestCount
-    totals.skipped += result.result.skippedTestCount
-    totals.total += result.result.testCount
-
-    printTestResults(
-        result.name,
-        result.result.successfulTestCount,
-        result.result.failedTestCount,
-        result.result.skippedTestCount,
-        result.result.testCount
-    )
-  }
-
-  if (!testResults.isEmpty()) {
-    printTestResults(
-        "Project Total",
-        totals.success,
-        totals.failed,
-        totals.skipped,
-        totals.total
-    )
-  }
-}
-
-private printTestResults(title, passed, failed, skipped, total) {
-  def style = Style.Success
-  if (failed > 0) {
-    style = Style.Failure
-  } else if (skipped > 0) {
-    style = Style.Info
-  }
-
-  def summary = " ${passed} / ${total} passed, ${failed} failed, ${skipped} skipped "
-  def summaryTitle = " ${title.capitalize()} "
-  def styledOut = services.get(StyledTextOutputFactory).create("elements-out")
-
-  styledOut.withStyle(style).println('╔═' + summaryTitle + '═' * (summary.length() - summaryTitle.length() -1) + '╗')
-  styledOut.withStyle(style).println('║' + summary + '║')
-  styledOut.withStyle(style).println('╚' + '═' * summary.length() + '╝')
-}
-
 
 /*
  * Below is the functionality to publish the `library` module to Maven Central (Sonatype) using the

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 ext {
-  composeVersion = "1.3.1"
-  composeUiVersion = "1.3.3"
+  composeVersion = "1.4.3"
+  composeCompilerVersion = "1.4.7"
 }
 
 dependencies {
@@ -14,21 +14,21 @@ dependencies {
   implementation "androidx.media3:media3-datasource-okhttp:$rootProject.ext.media3Version" // Custom HTTP
 
   // Misc
-  implementation 'androidx.core:core-ktx:1.9.0'
+  implementation 'androidx.core:core-ktx:1.10.1'
   implementation 'androidx.appcompat:appcompat:1.6.1'
   implementation 'androidx.media:media:1.6.0'
   implementation 'com.android.support.constraint:constraint-layout:2.0.4'
 
   // Jetpack Compose UI
-  implementation "androidx.compose.ui:ui:$composeUiVersion"
-  implementation "androidx.compose.ui:ui-tooling:$composeUiVersion"
-  implementation "androidx.compose.ui:ui-tooling-preview:$composeUiVersion"
+  implementation "androidx.compose.ui:ui:$composeVersion"
+  implementation "androidx.compose.ui:ui-tooling:$composeVersion"
+  implementation "androidx.compose.ui:ui-tooling-preview:$composeVersion"
   implementation "androidx.compose.material:material:$composeVersion"
   implementation "androidx.compose.material:material-icons-core:$composeVersion"
   implementation "androidx.compose.material:material-icons-extended:$composeVersion"
-  implementation 'androidx.activity:activity-compose:1.6.1'
+  implementation 'androidx.activity:activity-compose:1.7.1'
   implementation "androidx.navigation:navigation-compose:2.5.3"
-  implementation "com.google.accompanist:accompanist-navigation-animation:0.28.0"
+  implementation "com.google.accompanist:accompanist-navigation-animation:0.30.1"
 
 
   // Image Loading
@@ -58,7 +58,7 @@ android {
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_1_8
+    jvmTarget = JavaVersion.VERSION_17
   }
 
   buildFeatures {
@@ -67,12 +67,12 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
   }
 
   composeOptions {
-    kotlinCompilerExtensionVersion "1.4.3"
+    kotlinCompilerExtensionVersion composeCompilerVersion
   }
 
   lint {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
+android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=true
+android.nonFinalResIds=false
+android.nonTransitiveRClass=false
 android.useAndroidX=true
 org.gradle.jvmargs=-Xms512m

--- a/gradle/util/testOutput.gradle
+++ b/gradle/util/testOutput.gradle
@@ -1,0 +1,80 @@
+import org.gradle.internal.logging.text.StyledTextOutputFactory
+import static org.gradle.internal.logging.text.StyledTextOutput.Style
+
+/**
+ * Handles watching the test output for each gradle module, storing the results until the
+ * test suite has completed, then prints out the results in a condensed manner.
+ *
+ * To include this functionality in the project, you just need to apply this script in
+ * the root `build.gradle` file. e.g. `apply from: './gradle/testOutput.gradle'`
+ */
+
+ext {
+  moduleTestResults = []
+}
+
+allprojects {
+  // Collects test results which are then printed in buildFinished below
+  tasks.withType(Test).configureEach {
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+
+    testLogging {
+      outputs.upToDateWhen { false }
+      events "failed", "skipped", "standardOut"
+      exceptionFormat "full"
+
+      afterSuite { desc, result ->
+        if (!desc.parent) {
+          moduleTestResults.add([name: project.name, result: result])
+        }
+      }
+    }
+  }
+}
+
+gradle.buildFinished {
+  def testResults = ext.moduleTestResults
+  def totals = [success: 0, failed: 0, skipped: 0, total: 0]
+
+  testResults.forEach { result ->
+    totals.success += result.result.successfulTestCount
+    totals.failed += result.result.failedTestCount
+    totals.skipped += result.result.skippedTestCount
+    totals.total += result.result.testCount
+
+    printTestResults(
+        result.name,
+        result.result.successfulTestCount,
+        result.result.failedTestCount,
+        result.result.skippedTestCount,
+        result.result.testCount
+    )
+  }
+
+  if (!testResults.isEmpty()) {
+    printTestResults(
+        "Project Total",
+        totals.success,
+        totals.failed,
+        totals.skipped,
+        totals.total
+    )
+  }
+}
+
+private printTestResults(title, passed, failed, skipped, total) {
+  def style = Style.Success
+  if (failed > 0) {
+    style = Style.Failure
+  } else if (skipped > 0) {
+    style = Style.Info
+  }
+
+  def summary = " ${passed} / ${total} passed, ${failed} failed, ${skipped} skipped "
+  def summaryTitle = " ${title.capitalize()} "
+  def styledOut = services.get(StyledTextOutputFactory).create("styledTests-out")
+
+  styledOut.withStyle(style).println('╔═' + summaryTitle + '═' * (summary.length() - summaryTitle.length() - 1) + '╗')
+  styledOut.withStyle(style).println('║' + summary + '║')
+  styledOut.withStyle(style).println('╚' + '═' * summary.length() + '╝')
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   api "androidx.media3:media3-exoplayer-smoothstreaming:$rootProject.ext.media3Version"
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation "org.robolectric:robolectric:4.9.2"
+  testImplementation "org.robolectric:robolectric:4.10"
 }
 
 android {
@@ -41,8 +41,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
   }
 
   testOptions {


### PR DESCRIPTION
### Updates:
 - AGP to `8.0.1` (was `7.4.2`)
 - Kotlin to `1.8.21` (was `1.8.10`)
 - Moves the test result output to a separate gradle file
 - Demo dependencies