### PR TITLE
[#795] Updated Demo Support Libs

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   implementation 'androidx.core:core-ktx:1.10.1'
   implementation 'androidx.appcompat:appcompat:1.6.1'
   implementation 'androidx.media:media:1.6.0'
-  implementation 'com.android.support.constraint:constraint-layout:2.0.4'
+  implementation "androidx.constraintlayout:constraintlayout:2.1.4"
 
   // Jetpack Compose UI
   implementation "androidx.compose.ui:ui:$composeVersion"

--- a/demo/gradle.properties
+++ b/demo/gradle.properties
@@ -1,2 +1,1 @@
 android.useAndroidX=true
-android.enableJetifier=true


### PR DESCRIPTION
Addresses #795 

### Updates:
 - Updated the Demo to use the AndroidX ConstraintLayout 
 - Disabled Jettifier